### PR TITLE
feat: add memory Nostr repository

### DIFF
--- a/src/core/repository/memory-repository.test.ts
+++ b/src/core/repository/memory-repository.test.ts
@@ -1,0 +1,182 @@
+import type { NostrEvent } from "nostr-tools";
+import { describe, expect, test } from "vitest";
+import { MemoryNostrRepository } from "./memory-repository";
+
+const event = (
+  overrides: Partial<NostrEvent> & { id: string },
+): NostrEvent => ({
+  id: overrides.id,
+  pubkey: overrides.pubkey ?? "pubkey-a",
+  created_at: overrides.created_at ?? 100,
+  kind: overrides.kind ?? 1,
+  tags: overrides.tags ?? [],
+  content: overrides.content ?? "",
+  sig: overrides.sig ?? `${overrides.id}-sig`,
+});
+
+describe("MemoryNostrRepository", () => {
+  test("stores raw events by id and reports duplicates without replacing the original event", async () => {
+    const repository = new MemoryNostrRepository();
+    const first = event({ id: "event-1", content: "first" });
+    const duplicate = event({ id: "event-1", content: "duplicate" });
+
+    await expect(
+      repository.putEvent({ event: first, relay: "wss://relay-a.example" }),
+    ).resolves.toEqual({ type: "inserted", event: first });
+    await expect(
+      repository.putEvent({ event: duplicate, relay: "wss://relay-b.example" }),
+    ).resolves.toEqual({ type: "duplicate", event: first });
+
+    await expect(repository.getEvent("event-1")).resolves.toEqual(first);
+    await expect(repository.getEvents(["missing", "event-1"])).resolves.toEqual(
+      [first],
+    );
+  });
+
+  test("tracks all relays that have seen an event", async () => {
+    const repository = new MemoryNostrRepository();
+    const note = event({ id: "event-1" });
+
+    await repository.putEvent({ event: note, relay: "wss://relay-a.example" });
+    await repository.putEvent({ event: note, relay: "wss://relay-b.example" });
+    await repository.markSeen("event-1", "wss://relay-c.example");
+
+    await expect(repository.getSeenRelays("event-1")).resolves.toEqual([
+      "wss://relay-a.example",
+      "wss://relay-b.example",
+      "wss://relay-c.example",
+    ]);
+  });
+
+  test("resolves the newest regular replaceable event by kind and pubkey", async () => {
+    const repository = new MemoryNostrRepository();
+    const oldProfile = event({
+      id: "old-profile",
+      kind: 0,
+      pubkey: "alice",
+      created_at: 100,
+    });
+    const newProfile = event({
+      id: "new-profile",
+      kind: 0,
+      pubkey: "alice",
+      created_at: 200,
+    });
+    const staleProfile = event({
+      id: "stale-profile",
+      kind: 0,
+      pubkey: "alice",
+      created_at: 150,
+    });
+
+    await repository.putEvent({
+      event: oldProfile,
+      relay: "wss://relay.example",
+    });
+    await repository.putEvent({
+      event: newProfile,
+      relay: "wss://relay.example",
+    });
+    await repository.putEvent({
+      event: staleProfile,
+      relay: "wss://relay.example",
+    });
+
+    await expect(repository.getLatestReplaceable(0, "alice")).resolves.toEqual(
+      newProfile,
+    );
+  });
+
+  test("resolves the newest parameterized replaceable event by kind, pubkey, and d tag", async () => {
+    const repository = new MemoryNostrRepository();
+    const oldList = event({
+      id: "old-list",
+      kind: 30000,
+      pubkey: "alice",
+      created_at: 100,
+      tags: [["d", "bookmarks"]],
+    });
+    const newList = event({
+      id: "new-list",
+      kind: 30000,
+      pubkey: "alice",
+      created_at: 200,
+      tags: [["d", "bookmarks"]],
+    });
+    const otherList = event({
+      id: "other-list",
+      kind: 30000,
+      pubkey: "alice",
+      created_at: 300,
+      tags: [["d", "mute"]],
+    });
+
+    await repository.putEvent({ event: oldList, relay: "wss://relay.example" });
+    await repository.putEvent({ event: newList, relay: "wss://relay.example" });
+    await repository.putEvent({
+      event: otherList,
+      relay: "wss://relay.example",
+    });
+
+    await expect(
+      repository.getParameterizedReplaceable(30000, "alice", "bookmarks"),
+    ).resolves.toEqual(newList);
+    await expect(
+      repository.getParameterizedReplaceable(30000, "alice", "mute"),
+    ).resolves.toEqual(otherList);
+  });
+
+  test("queries events by ids, authors, kinds, and tag filters", async () => {
+    const repository = new MemoryNostrRepository();
+    const aliceNote = event({
+      id: "alice-note",
+      pubkey: "alice",
+      kind: 1,
+      created_at: 100,
+      tags: [
+        ["p", "bob"],
+        ["t", "nostr"],
+      ],
+    });
+    const bobReaction = event({
+      id: "bob-reaction",
+      pubkey: "bob",
+      kind: 7,
+      created_at: 200,
+      tags: [["e", "alice-note"]],
+    });
+    const carolNote = event({
+      id: "carol-note",
+      pubkey: "carol",
+      kind: 1,
+      created_at: 300,
+      tags: [["t", "solidjs"]],
+    });
+
+    await repository.putEvent({
+      event: aliceNote,
+      relay: "wss://relay.example",
+    });
+    await repository.putEvent({
+      event: bobReaction,
+      relay: "wss://relay.example",
+    });
+    await repository.putEvent({
+      event: carolNote,
+      relay: "wss://relay.example",
+    });
+
+    await expect(
+      repository.queryEvents({ authors: ["alice", "carol"], kinds: [1] }),
+    ).resolves.toEqual([carolNote, aliceNote]);
+    await expect(
+      repository.queryEvents({ tags: { p: ["bob"] } }),
+    ).resolves.toEqual([aliceNote]);
+    await expect(
+      repository.queryEvents({
+        ids: ["bob-reaction"],
+        tags: { e: ["alice-note"] },
+      }),
+    ).resolves.toEqual([bobReaction]);
+  });
+});

--- a/src/core/repository/memory-repository.ts
+++ b/src/core/repository/memory-repository.ts
@@ -1,0 +1,174 @@
+import type { NostrEvent } from "nostr-tools";
+import type {
+  NostrEventQuery,
+  NostrRepository,
+  PutEventInput,
+  PutEventResult,
+  RelayUrl,
+  StoredNostrEvent,
+} from "./nostr-repository";
+
+const parameterizedReplaceableKindStart = 30_000;
+const parameterizedReplaceableKindEnd = 39_999;
+
+const regularReplaceableKinds = new Set([0, 3]);
+
+const isRegularReplaceableKind = (kind: number) =>
+  regularReplaceableKinds.has(kind) || (kind >= 10_000 && kind < 20_000);
+
+const isParameterizedReplaceableKind = (kind: number) =>
+  kind >= parameterizedReplaceableKindStart &&
+  kind <= parameterizedReplaceableKindEnd;
+
+const getDTag = (event: NostrEvent) =>
+  event.tags.find((tag) => tag[0] === "d")?.[1] ?? "";
+
+const regularReplaceableKey = (kind: number, pubkey: string) =>
+  `${kind}:${pubkey}`;
+
+const parameterizedReplaceableKey = (kind: number, pubkey: string, d: string) =>
+  `${kind}:${pubkey}:${d}`;
+
+const isNewer = (candidate: NostrEvent, current: NostrEvent | undefined) => {
+  if (!current) {
+    return true;
+  }
+  if (candidate.created_at !== current.created_at) {
+    return candidate.created_at > current.created_at;
+  }
+  return candidate.id > current.id;
+};
+
+const eventMatchesQuery = (event: NostrEvent, query: NostrEventQuery) => {
+  if (query.ids && !query.ids.includes(event.id)) {
+    return false;
+  }
+  if (query.authors && !query.authors.includes(event.pubkey)) {
+    return false;
+  }
+  if (query.kinds && !query.kinds.includes(event.kind)) {
+    return false;
+  }
+  if (query.tags) {
+    for (const [name, values] of Object.entries(query.tags)) {
+      const hasTagValue = event.tags.some(
+        (tag) =>
+          tag[0] === name && tag[1] !== undefined && values.includes(tag[1]),
+      );
+      if (!hasTagValue) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+export class MemoryNostrRepository implements NostrRepository {
+  readonly #events = new Map<string, StoredNostrEvent>();
+  readonly #latestReplaceable = new Map<string, string>();
+  readonly #latestParameterizedReplaceable = new Map<string, string>();
+
+  async putEvent(input: PutEventInput): Promise<PutEventResult> {
+    const stored = this.#events.get(input.event.id);
+    if (stored) {
+      if (input.relay) {
+        this.#addSeenRelay(stored, input.relay);
+      }
+      return { type: "duplicate", event: stored.event };
+    }
+
+    this.#events.set(input.event.id, {
+      event: input.event,
+      seenRelays: input.relay ? [input.relay] : [],
+    });
+    this.#indexReplaceable(input.event);
+
+    return { type: "inserted", event: input.event };
+  }
+
+  async markSeen(id: string, relay: RelayUrl): Promise<void> {
+    const stored = this.#events.get(id);
+    if (!stored) {
+      return;
+    }
+    this.#addSeenRelay(stored, relay);
+  }
+
+  async getEvent(id: string): Promise<NostrEvent | undefined> {
+    return this.#events.get(id)?.event;
+  }
+
+  async getEvents(ids: readonly string[]): Promise<NostrEvent[]> {
+    return ids
+      .map((id) => this.#events.get(id)?.event)
+      .filter((event): event is NostrEvent => event !== undefined);
+  }
+
+  async getSeenRelays(id: string): Promise<RelayUrl[]> {
+    return [...(this.#events.get(id)?.seenRelays ?? [])];
+  }
+
+  async queryEvents(query: NostrEventQuery): Promise<NostrEvent[]> {
+    const events = [...this.#events.values()]
+      .map((stored) => stored.event)
+      .filter((event) => eventMatchesQuery(event, query))
+      .sort((a, b) => b.created_at - a.created_at || b.id.localeCompare(a.id));
+
+    return query.limit ? events.slice(0, query.limit) : events;
+  }
+
+  async getLatestReplaceable(
+    kind: number,
+    pubkey: string,
+  ): Promise<NostrEvent | undefined> {
+    const id = this.#latestReplaceable.get(regularReplaceableKey(kind, pubkey));
+    return id ? this.#events.get(id)?.event : undefined;
+  }
+
+  async getParameterizedReplaceable(
+    kind: number,
+    pubkey: string,
+    d: string,
+  ): Promise<NostrEvent | undefined> {
+    const id = this.#latestParameterizedReplaceable.get(
+      parameterizedReplaceableKey(kind, pubkey, d),
+    );
+    return id ? this.#events.get(id)?.event : undefined;
+  }
+
+  #addSeenRelay(stored: StoredNostrEvent, relay: RelayUrl) {
+    if (stored.seenRelays.includes(relay)) {
+      return;
+    }
+    (stored.seenRelays as RelayUrl[]).push(relay);
+  }
+
+  #indexReplaceable(event: NostrEvent) {
+    if (isRegularReplaceableKind(event.kind)) {
+      const key = regularReplaceableKey(event.kind, event.pubkey);
+      const current = this.#eventForIndexedId(this.#latestReplaceable.get(key));
+      if (isNewer(event, current)) {
+        this.#latestReplaceable.set(key, event.id);
+      }
+      return;
+    }
+
+    if (isParameterizedReplaceableKind(event.kind)) {
+      const key = parameterizedReplaceableKey(
+        event.kind,
+        event.pubkey,
+        getDTag(event),
+      );
+      const current = this.#eventForIndexedId(
+        this.#latestParameterizedReplaceable.get(key),
+      );
+      if (isNewer(event, current)) {
+        this.#latestParameterizedReplaceable.set(key, event.id);
+      }
+    }
+  }
+
+  #eventForIndexedId(id: string | undefined) {
+    return id ? this.#events.get(id)?.event : undefined;
+  }
+}

--- a/src/core/repository/nostr-repository.ts
+++ b/src/core/repository/nostr-repository.ts
@@ -1,0 +1,43 @@
+import type { NostrEvent } from "nostr-tools";
+
+export type RelayUrl = string;
+
+export type StoredNostrEvent = {
+  event: NostrEvent;
+  seenRelays: readonly RelayUrl[];
+};
+
+export type PutEventInput = {
+  event: NostrEvent;
+  relay?: RelayUrl;
+};
+
+export type PutEventResult =
+  | { type: "inserted"; event: NostrEvent }
+  | { type: "duplicate"; event: NostrEvent };
+
+export type NostrEventQuery = {
+  ids?: readonly string[];
+  authors?: readonly string[];
+  kinds?: readonly number[];
+  tags?: Readonly<Record<string, readonly string[]>>;
+  limit?: number;
+};
+
+export interface NostrRepository {
+  putEvent(input: PutEventInput): Promise<PutEventResult>;
+  markSeen(id: string, relay: RelayUrl): Promise<void>;
+  getEvent(id: string): Promise<NostrEvent | undefined>;
+  getEvents(ids: readonly string[]): Promise<NostrEvent[]>;
+  getSeenRelays(id: string): Promise<RelayUrl[]>;
+  queryEvents(query: NostrEventQuery): Promise<NostrEvent[]>;
+  getLatestReplaceable(
+    kind: number,
+    pubkey: string,
+  ): Promise<NostrEvent | undefined>;
+  getParameterizedReplaceable(
+    kind: number,
+    pubkey: string,
+    d: string,
+  ): Promise<NostrEvent | undefined>;
+}


### PR DESCRIPTION
## Summary
- Add NostrRepository interface for the v1 raw event source of truth
- Add MemoryNostrRepository with id deduplication and seen relay tracking
- Add replaceable / parameterized replaceable resolution and basic query support
- Cover repository behavior with Vitest tests

## Test Plan
- pnpm test -- --run src/core/repository/memory-repository.test.ts
- pnpm exec tsc --noEmit
- pnpm exec biome check src/core/repository

Linear: EYE-94