### PR TITLE
feat: add nostr transport boundary

### DIFF
--- a/src/core/transport/rx-nostr-transport.test.ts
+++ b/src/core/transport/rx-nostr-transport.test.ts
@@ -1,0 +1,146 @@
+import type { RxNostr } from "rx-nostr";
+import { Observable, Subject, of } from "rxjs";
+import { describe, expect, test, vi } from "vitest";
+import { RxNostrTransport } from "./rx-nostr-transport";
+import type { NostrSubscription } from "./transport";
+
+const createFakeRxNostr = () => {
+  const allMessages$ = new Subject<unknown>();
+  const connectionState$ = new Subject<unknown>();
+  const useResult$ = new Subject<unknown>();
+
+  const rxNostr = {
+    setDefaultRelays: vi.fn(),
+    use: vi.fn(() => useResult$.asObservable()),
+    send: vi.fn(() => of({ ok: true, done: true })),
+    createAllMessageObservable: vi.fn(() => allMessages$.asObservable()),
+    createConnectionStateObservable: vi.fn(() =>
+      connectionState$.asObservable(),
+    ),
+    dispose: vi.fn(),
+  } as unknown as RxNostr;
+
+  return { rxNostr, allMessages$, connectionState$, useResult$ };
+};
+
+describe("RxNostrTransport", () => {
+  test("sets default relays through the wrapped rx-nostr instance", () => {
+    const { rxNostr } = createFakeRxNostr();
+    const transport = new RxNostrTransport(rxNostr);
+
+    transport.setDefaultRelays(["wss://relay.example"]);
+
+    expect(rxNostr.setDefaultRelays).toHaveBeenCalledWith([
+      "wss://relay.example",
+    ]);
+  });
+
+  test("creates backward subscriptions without exposing rx-nostr to callers", () => {
+    const { rxNostr } = createFakeRxNostr();
+    const transport = new RxNostrTransport(rxNostr);
+
+    const subscription = transport.subscribe({
+      filters: { kinds: [1], limit: 10, "#a": ["kind:pubkey:d"] },
+      relays: ["wss://relay.example"],
+      mode: "backward",
+    });
+
+    expect(rxNostr.use).toHaveBeenCalledOnce();
+    expect(rxNostr.use).toHaveBeenCalledWith(expect.anything(), {
+      on: {
+        relays: ["wss://relay.example"],
+        defaultReadRelays: false,
+      },
+    });
+
+    subscription.emit({ kinds: [1], limit: 10, "#a": ["kind:pubkey:d"] });
+    subscription.close();
+  });
+
+  test("closes subscriptions by unsubscribing observed rx-nostr streams", () => {
+    const unsubscribe = vi.fn();
+    const rxNostr = {
+      setDefaultRelays: vi.fn(),
+      use: vi.fn(
+        () =>
+          new Observable(() => {
+            return unsubscribe;
+          }),
+      ),
+      send: vi.fn(),
+      createAllMessageObservable: vi.fn(),
+      createConnectionStateObservable: vi.fn(),
+      dispose: vi.fn(),
+    } as unknown as RxNostr;
+    const transport = new RxNostrTransport(rxNostr);
+    const subscription = transport.subscribe({
+      filters: { kinds: [1] },
+      mode: "forward",
+    });
+
+    const observableSubscription = subscription.events$.subscribe();
+    subscription.close();
+
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(observableSubscription.closed).toBe(true);
+  });
+
+  test("passes publish requests to rx-nostr send", () => {
+    const { rxNostr } = createFakeRxNostr();
+    const transport = new RxNostrTransport(rxNostr);
+
+    const event = {
+      kind: 1,
+      content: "hello",
+      tags: [],
+      created_at: 1,
+    };
+
+    const results: unknown[] = [];
+    transport
+      .publish(event, { relays: ["wss://relay.example"] })
+      .subscribe((packet) => {
+        results.push(packet);
+      });
+
+    expect(rxNostr.send).toHaveBeenCalledWith(event, {
+      on: {
+        relays: ["wss://relay.example"],
+        defaultWriteRelays: false,
+      },
+    });
+    expect(results).toEqual([{ ok: true, done: true }]);
+  });
+
+  test("exposes observation streams and dispose without leaking rx-nostr", () => {
+    const { rxNostr, allMessages$, connectionState$ } = createFakeRxNostr();
+    const transport = new RxNostrTransport(rxNostr);
+
+    const messages: unknown[] = [];
+    const states: unknown[] = [];
+    transport.observeMessages().subscribe((packet) => messages.push(packet));
+    transport
+      .observeConnectionState()
+      .subscribe((packet) => states.push(packet));
+
+    allMessages$.next({
+      type: "NOTICE",
+      from: "wss://relay.example",
+      notice: "hi",
+    });
+    connectionState$.next({ from: "wss://relay.example", state: "connected" });
+    transport.dispose();
+
+    expect(messages).toEqual([
+      { type: "NOTICE", from: "wss://relay.example", notice: "hi" },
+    ]);
+    expect(states).toEqual([
+      { from: "wss://relay.example", state: "connected" },
+    ]);
+    expect(rxNostr.dispose).toHaveBeenCalledOnce();
+  });
+});
+
+expectType<NostrSubscription>(undefined as never);
+
+function expectType<T>(_value: T) {}

--- a/src/core/transport/rx-nostr-transport.ts
+++ b/src/core/transport/rx-nostr-transport.ts
@@ -1,0 +1,149 @@
+import type { EventParameters } from "nostr-typedef";
+import {
+  type LazyFilter,
+  type RxNostr,
+  type RxNostrOnParams,
+  createRxBackwardReq,
+  createRxForwardReq,
+} from "rx-nostr";
+import { Observable, Subscription } from "rxjs";
+import type {
+  NostrSubscription,
+  NostrTransport,
+  NostrTransportConnectionStatePacket,
+  NostrTransportEventPacket,
+  NostrTransportFilter,
+  NostrTransportMessagePacket,
+  NostrTransportPublishOptions,
+  NostrTransportPublishPacket,
+  NostrTransportRelayOptions,
+  NostrTransportSubscribeOptions,
+  RelayUrl,
+} from "./transport";
+
+export class RxNostrTransport implements NostrTransport {
+  constructor(private readonly rxNostr: RxNostr) {}
+
+  setDefaultRelays(relays: readonly RelayUrl[]): void {
+    this.rxNostr.setDefaultRelays([...relays]);
+  }
+
+  subscribe(options: NostrTransportSubscribeOptions): NostrSubscription {
+    const rxReq =
+      options.mode === "forward" ? createRxForwardReq() : createRxBackwardReq();
+    const source$ = this.rxNostr.use(rxReq, {
+      on: toRxNostrOnParams(options, "read"),
+    }) as Observable<NostrTransportEventPacket>;
+    const subscriptions = new Subscription();
+    const events$ = new Observable<NostrTransportEventPacket>((subscriber) => {
+      const subscription = source$.subscribe(subscriber);
+      subscriptions.add(subscription);
+      return () => {
+        subscription.unsubscribe();
+        subscriptions.remove(subscription);
+      };
+    });
+
+    return {
+      events$,
+      emit(filters) {
+        rxReq.emit(toLazyFilters(filters));
+      },
+      close() {
+        subscriptions.unsubscribe();
+        if ("over" in rxReq) {
+          rxReq.over();
+        }
+      },
+    };
+  }
+
+  publish(
+    event: EventParameters,
+    options?: NostrTransportPublishOptions,
+  ): Observable<NostrTransportPublishPacket> {
+    return this.rxNostr.send(event, {
+      on: toRxNostrOnParams(options, "write"),
+    }) as Observable<NostrTransportPublishPacket>;
+  }
+
+  observeMessages(): Observable<NostrTransportMessagePacket> {
+    return this.rxNostr.createAllMessageObservable() as Observable<NostrTransportMessagePacket>;
+  }
+
+  observeConnectionState(): Observable<NostrTransportConnectionStatePacket> {
+    return this.rxNostr.createConnectionStateObservable() as Observable<NostrTransportConnectionStatePacket>;
+  }
+
+  dispose(): void {
+    this.rxNostr.dispose();
+  }
+}
+
+export const subscribeToTransport = (
+  transport: NostrTransport,
+  options: NostrTransportSubscribeOptions,
+): NostrSubscription => {
+  const subscription = transport.subscribe(options);
+  subscription.emit(options.filters);
+  return subscription;
+};
+
+export const subscribeToTransportEvents = (
+  transport: NostrTransport,
+  options: NostrTransportSubscribeOptions,
+  onEvent: (packet: NostrTransportEventPacket) => void,
+): NostrSubscription => {
+  const subscription = transport.subscribe(options);
+  const observableSubscription = subscription.events$.subscribe(onEvent);
+  const originalClose = subscription.close;
+
+  return {
+    events$: subscription.events$,
+    emit: subscription.emit,
+    close() {
+      observableSubscription.unsubscribe();
+      originalClose();
+    },
+  };
+};
+
+export const createTransportDisposer = (
+  ...subscriptions: NostrSubscription[]
+) => {
+  const disposables = new Subscription();
+  for (const subscription of subscriptions) {
+    disposables.add(() => subscription.close());
+  }
+  return () => disposables.unsubscribe();
+};
+
+const toRxNostrOnParams = (
+  options: NostrTransportRelayOptions | undefined,
+  direction: "read" | "write",
+): RxNostrOnParams | undefined => {
+  if (!options) {
+    return undefined;
+  }
+
+  const relays = options.relays ? [...options.relays] : undefined;
+
+  return {
+    relays,
+    defaultReadRelays:
+      direction === "read" ? (options.defaultReadRelays ?? !relays) : undefined,
+    defaultWriteRelays:
+      direction === "write"
+        ? (options.defaultWriteRelays ?? !relays)
+        : undefined,
+  };
+};
+
+const toLazyFilters = (
+  filters: NostrTransportFilter | readonly NostrTransportFilter[],
+): LazyFilter | LazyFilter[] => {
+  if (Array.isArray(filters)) {
+    return filters.map((filter) => ({ ...filter }));
+  }
+  return { ...filters };
+};

--- a/src/core/transport/transport.ts
+++ b/src/core/transport/transport.ts
@@ -1,0 +1,88 @@
+import type { NostrEvent } from "nostr-tools";
+import type { EventParameters } from "nostr-typedef";
+import type { Observable } from "rxjs";
+
+export type RelayUrl = string;
+
+export type NostrTransportMode = "backward" | "forward";
+
+export type NostrTransportFilter = {
+  ids?: string[];
+  authors?: string[];
+  kinds?: number[];
+  since?: number | (() => number);
+  until?: number | (() => number);
+  limit?: number;
+  search?: string;
+  [tag: `#${string}`]: string[] | undefined;
+};
+
+export type NostrTransportRelayOptions = {
+  relays?: readonly RelayUrl[];
+  defaultReadRelays?: boolean;
+  defaultWriteRelays?: boolean;
+};
+
+export type NostrTransportSubscribeOptions = NostrTransportRelayOptions & {
+  filters: NostrTransportFilter | readonly NostrTransportFilter[];
+  mode?: NostrTransportMode;
+};
+
+export type NostrTransportPublishOptions = NostrTransportRelayOptions;
+
+export type NostrTransportEventPacket = {
+  type: "EVENT";
+  from: RelayUrl;
+  subId: string;
+  event: NostrEvent;
+};
+
+export type NostrTransportConnectionState =
+  | "initialized"
+  | "connecting"
+  | "connected"
+  | "waiting-for-retrying"
+  | "retrying"
+  | "dormant"
+  | "error"
+  | "rejected"
+  | "terminated";
+
+export type NostrTransportConnectionStatePacket = {
+  from: RelayUrl;
+  state: NostrTransportConnectionState;
+};
+
+export type NostrTransportMessagePacket = {
+  from: RelayUrl;
+  type: string;
+  message?: unknown;
+  [key: string]: unknown;
+};
+
+export type NostrTransportPublishPacket = {
+  from: RelayUrl;
+  type: "OK";
+  eventId: string;
+  ok: boolean;
+  done: boolean;
+  notice?: string;
+};
+
+export interface NostrSubscription {
+  readonly events$: Observable<NostrTransportEventPacket>;
+  emit(filters: NostrTransportFilter | readonly NostrTransportFilter[]): void;
+  close(): void;
+}
+
+export interface NostrTransport {
+  setDefaultRelays(relays: readonly RelayUrl[]): void;
+  subscribe(options: NostrTransportSubscribeOptions): NostrSubscription;
+  publish(
+    event: EventParameters,
+    options?: NostrTransportPublishOptions,
+  ): Observable<NostrTransportPublishPacket>;
+  observeMessages(): Observable<NostrTransportMessagePacket>;
+  observeConnectionState(): Observable<NostrTransportConnectionStatePacket>;
+  dispose(): void;
+}


### PR DESCRIPTION
## Summary
- add a small `NostrTransport` interface for relay defaults, subscriptions, publish, message/connection observation, and disposal
- add `RxNostrTransport` as the rx-nostr adapter, keeping request creation and relay lifecycle behavior delegated to rx-nostr
- add unit coverage for relay defaults, subscription creation/closing, publish delegation, observation streams, and arbitrary `#tag` filters

## Validation
- `pnpm test -- --run src/core/transport/rx-nostr-transport.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec biome check src/core/transport`

## Review Focus
- Please check that the new transport abstraction is minimal enough for the v1 core boundary without leaking `rx-nostr` to repository/projection callers.
- Please check the subscription lifecycle: `close()` now owns teardown for observed rx-nostr streams and still lets rx-nostr handle relay CLOSE/EOSE behavior.
- Please check whether the current transport packet/filter types are broad enough for the next repository/projection integration step.
