### PR TITLE
feat: add TanStack DB read-model collections

### DIFF
--- a/docs/nostr-client-core-design-v1.md
+++ b/docs/nostr-client-core-design-v1.md
@@ -662,6 +662,52 @@ Use TanStack DB live queries for event/profile/timeline data.
 - IndexedDB cache internals
 ```
 
+### Column and Event Renderer Migration Boundaries
+
+The current UI has two important legacy entry points:
+
+```txt
+src/features/Column/components/ColumnContent.tsx
+src/shared/components/Event.tsx
+src/shared/components/EventByID.tsx
+src/shared/components/InfiniteEvents.tsx
+src/shared/libs/query.ts
+```
+
+For v1, keep `ColumnContent` and the individual column components as UI composition and layout owners. A column should describe what timeline/query it needs, but it should not directly create `rx-nostr` requests, parse relay packets, or write cache data. Column-local Solid state should remain limited to layout, temporary column state, dialogs, and view-local controls.
+
+Event renderers should become read-model consumers. `EventByID` should resolve an event row through the v1 Solid hook, then pass a parsed/renderable view model into `Event`. `Event` may continue to dispatch by event kind, but it should not fetch related events or mutate the repository. Rendering unknown events from the raw event row is acceptable as a fallback.
+
+The migration path should preserve compatibility exports so existing call sites can move gradually:
+
+```txt
+legacy column component
+  ↓ describes timeline/query params
+v1 hook ensures query through QueryClient
+  ↓ reads TanStack DB live query
+EventByID / InfiniteEvents render read-model rows
+```
+
+### Filter Issuance Policy
+
+Relay filters should be issued only by the v1 query layer:
+
+```txt
+UI / column params
+  ↓
+QueryClient.ensure* API
+  ↓
+QueryPlanner creates filters, relay choices, chunking, and priorities
+  ↓
+QueryRegistry reuses or reference-counts active work
+  ↓
+RxNostrTransport emits filters
+```
+
+Do not emit filters directly from column components, event renderers, projectors, or TanStack DB collection code. This prevents duplicate subscriptions across columns and keeps relay traffic policy testable.
+
+`cacheAndEmitRelatedEvent`-style behavior should be replaced by explicit related-event policy. Related event fetches may still be triggered, but only through `QueryClient`/`RelatedEventPolicy`, with clear reasons such as reply context, quoted event preview, repost source, or profile metadata. Projectors should record relationships into read models; they should not perform network fetches.
+
 ### Timeline Hook Sketch
 
 ```tsx

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@solid-primitives/resize-observer": "2.1.0",
     "@solid-primitives/scheduled": "1.5.0",
     "@solidjs/router": "0.13.6",
+    "@tanstack/db": "0.6.5",
     "@tanstack/solid-query": "5.66.2",
     "@tanstack/solid-query-devtools": "5.66.2",
     "@tanstack/solid-virtual": "3.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@solidjs/router':
         specifier: 0.13.6
         version: 0.13.6(solid-js@1.9.4)
+      '@tanstack/db':
+        specifier: 0.6.5
+        version: 0.6.5(typescript@5.7.3)
       '@tanstack/solid-query':
         specifier: 5.66.2
         version: 5.66.2(solid-js@1.9.4)
@@ -1536,11 +1539,28 @@ packages:
     peerDependencies:
       solid-js: ^1.8.6
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tanstack/db-ivm@0.1.18':
+    resolution: {integrity: sha512-+pZJiRKdoKRM5Epq9T7otD9ZJl82pRFauo7LKuJGrarjVKQ7r+QQlPe3kGdN9LEKSnuNGIWjX9OOY4M8kH4eLw==}
+    peerDependencies:
+      typescript: '>=4.7'
+
+  '@tanstack/db@0.6.5':
+    resolution: {integrity: sha512-gtCuAo4UtC9SR/kTMu5fVEff6qZ2R1FZi9X7MybtHKA6wve7RePifGG6qBI4OmMB+7juT5/+glNbnqZOrG0/pg==}
+    peerDependencies:
+      typescript: '>=4.7'
+
+  '@tanstack/pacer-lite@0.2.2':
+    resolution: {integrity: sha512-eQ1MyLKCHyXiH7NbdmB80W77OhiMgGBUb+qDx/8WMGbwg5Lf/NlfD0TfNYAqY77i8V3AxoDoYdICrQE5ADw4Yw==}
+    engines: {node: '>=18'}
 
   '@tanstack/query-core@5.66.2':
     resolution: {integrity: sha512-GL/Rx7rIUxyYgJPWSpFjz09lizvAAZut2RueuRXnedAJzJMI+NxpwKA6dojJ9gc26RdUviH5pvSvEiYXo8vSTg==}
@@ -2347,6 +2367,10 @@ packages:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
     engines: {node: '>= 6'}
 
+  fractional-indexing@3.2.0:
+    resolution: {integrity: sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
@@ -2401,7 +2425,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -3094,6 +3118,9 @@ packages:
     peerDependencies:
       solid-js: ^1.3
 
+  sorted-btree@1.8.1:
+    resolution: {integrity: sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3108,6 +3135,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -5048,6 +5076,8 @@ snapshots:
     dependencies:
       solid-js: 1.9.4
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
       ejs: 3.1.10
@@ -5058,6 +5088,21 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@tanstack/db-ivm@0.1.18(typescript@5.7.3)':
+    dependencies:
+      fractional-indexing: 3.2.0
+      sorted-btree: 1.8.1
+      typescript: 5.7.3
+
+  '@tanstack/db@0.6.5(typescript@5.7.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@tanstack/db-ivm': 0.1.18(typescript@5.7.3)
+      '@tanstack/pacer-lite': 0.2.2
+      typescript: 5.7.3
+
+  '@tanstack/pacer-lite@0.2.2': {}
 
   '@tanstack/query-core@5.66.2': {}
 
@@ -6325,6 +6370,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
 
+  fractional-indexing@3.2.0: {}
+
   fs-extra@9.1.0:
     dependencies:
       at-least-node: 1.0.0
@@ -7136,6 +7183,8 @@ snapshots:
       solid-js: 1.9.4
     transitivePeerDependencies:
       - supports-color
+
+  sorted-btree@1.8.1: {}
 
   source-map-js@1.2.1: {}
 

--- a/src/core/db/collections.test.ts
+++ b/src/core/db/collections.test.ts
@@ -1,0 +1,104 @@
+import type { NostrEvent } from "nostr-tools";
+import { describe, expect, test } from "vitest";
+import { createNostrCollections } from "./collections";
+import {
+  projectEventRow,
+  projectProfileRow,
+  shouldReplaceProfileRow,
+} from "./projectors/profile";
+
+const event = (
+  overrides: Partial<NostrEvent> & { id: string },
+): NostrEvent => ({
+  id: overrides.id,
+  pubkey: overrides.pubkey ?? "pubkey-a",
+  created_at: overrides.created_at ?? 100,
+  kind: overrides.kind ?? 1,
+  tags: overrides.tags ?? [],
+  content: overrides.content ?? "",
+  sig: overrides.sig ?? `${overrides.id}-sig`,
+});
+
+describe("nostr TanStack DB collections", () => {
+  test("creates local UI read-model collections keyed by stable row ids", async () => {
+    const collections = createNostrCollections();
+    const note = event({ id: "event-1", content: "hello" });
+    const eventRow = projectEventRow(note, {
+      receivedAt: 1_000,
+      seenRelays: ["wss://relay.example"],
+    });
+
+    await collections.events.insert(eventRow).isPersisted.promise;
+    await collections.queryStates.insert({
+      id: "event:event-1",
+      filter: { ids: ["event-1"] },
+      status: "complete",
+      updatedAt: 1_001,
+    }).isPersisted.promise;
+
+    expect(collections.events.get("event-1")).toMatchObject({
+      id: "event-1",
+      pubkey: "pubkey-a",
+      kind: 1,
+      raw: note,
+      seenRelays: ["wss://relay.example"],
+    });
+    expect(collections.queryStates.get("event:event-1")).toMatchObject({
+      id: "event:event-1",
+      status: "complete",
+    });
+  });
+
+  test("projects kind 0 profile metadata without using TanStack DB as the raw repository", () => {
+    const rawProfile = event({
+      id: "profile-1",
+      kind: 0,
+      pubkey: "alice",
+      created_at: 200,
+      content: JSON.stringify({
+        name: "alice",
+        display_name: "Alice",
+        about: "hello nostr",
+        picture: "https://example.com/alice.png",
+        nip05: "alice@example.com",
+        lud16: "alice@example.com",
+      }),
+    });
+
+    expect(
+      projectProfileRow(rawProfile, {
+        receivedAt: 1_000,
+        seenRelays: ["wss://relay-a.example"],
+      }),
+    ).toEqual({
+      pubkey: "alice",
+      name: "alice",
+      displayName: "Alice",
+      about: "hello nostr",
+      picture: "https://example.com/alice.png",
+      nip05: "alice@example.com",
+      lud16: "alice@example.com",
+      sourceEventId: "profile-1",
+      updatedAt: 200,
+      receivedAt: 1_000,
+      seenRelays: ["wss://relay-a.example"],
+    });
+  });
+
+  test("profile projection ignores non-profile events and older kind 0 metadata", () => {
+    const oldProfile = projectProfileRow(
+      event({ id: "profile-old", kind: 0, pubkey: "alice", created_at: 100 }),
+      { receivedAt: 1_000 },
+    );
+    const newProfile = projectProfileRow(
+      event({ id: "profile-new", kind: 0, pubkey: "alice", created_at: 200 }),
+      { receivedAt: 1_001 },
+    );
+
+    expect(projectProfileRow(event({ id: "note-1", kind: 1 }))).toBeUndefined();
+    expect(oldProfile).toBeDefined();
+    expect(newProfile).toBeDefined();
+    expect(shouldReplaceProfileRow(newProfile, oldProfile)).toBe(true);
+    expect(shouldReplaceProfileRow(oldProfile, newProfile)).toBe(false);
+  });
+});

--- a/src/core/db/collections.test.ts
+++ b/src/core/db/collections.test.ts
@@ -1,8 +1,8 @@
 import type { NostrEvent } from "nostr-tools";
 import { describe, expect, test } from "vitest";
 import { createNostrCollections } from "./collections";
+import { projectEventRow } from "./projectors/event";
 import {
-  projectEventRow,
   projectProfileRow,
   shouldReplaceProfileRow,
 } from "./projectors/profile";

--- a/src/core/db/collections.ts
+++ b/src/core/db/collections.ts
@@ -1,0 +1,33 @@
+import { createCollection, localOnlyCollectionOptions } from "@tanstack/db";
+import type { LocalOnlyCollectionUtils } from "@tanstack/db";
+import type {
+  NostrCollections,
+  NostrEventRow,
+  NostrProfileRow,
+  NostrQueryStateRow,
+} from "./types";
+
+export const createNostrCollections = (): NostrCollections => ({
+  events: createCollection<NostrEventRow, string, LocalOnlyCollectionUtils>(
+    localOnlyCollectionOptions<NostrEventRow, string>({
+      id: "nostr-events",
+      getKey: (row) => row.id,
+    }),
+  ),
+  profiles: createCollection<NostrProfileRow, string, LocalOnlyCollectionUtils>(
+    localOnlyCollectionOptions<NostrProfileRow, string>({
+      id: "nostr-profiles",
+      getKey: (row) => row.pubkey,
+    }),
+  ),
+  queryStates: createCollection<
+    NostrQueryStateRow,
+    string,
+    LocalOnlyCollectionUtils
+  >(
+    localOnlyCollectionOptions<NostrQueryStateRow, string>({
+      id: "nostr-query-states",
+      getKey: (row) => row.id,
+    }),
+  ),
+});

--- a/src/core/db/projectors/event.ts
+++ b/src/core/db/projectors/event.ts
@@ -1,0 +1,21 @@
+import type { NostrEvent } from "nostr-tools";
+import type { NostrEventRow, ProjectionContext } from "../types";
+
+const getReceivedAt = (context?: ProjectionContext): number =>
+  context?.receivedAt ?? Date.now();
+
+const getSeenRelays = (context?: ProjectionContext): readonly string[] =>
+  context?.seenRelays ?? [];
+
+export const projectEventRow = (
+  event: NostrEvent,
+  context?: ProjectionContext,
+): NostrEventRow => ({
+  id: event.id,
+  pubkey: event.pubkey,
+  kind: event.kind,
+  createdAt: event.created_at,
+  raw: event,
+  seenRelays: getSeenRelays(context),
+  receivedAt: getReceivedAt(context),
+});

--- a/src/core/db/projectors/profile.ts
+++ b/src/core/db/projectors/profile.ts
@@ -1,0 +1,81 @@
+import type { NostrEvent } from "nostr-tools";
+import type {
+  NostrEventRow,
+  NostrProfileRow,
+  ProjectionContext,
+} from "../types";
+
+const getReceivedAt = (context?: ProjectionContext): number =>
+  context?.receivedAt ?? Date.now();
+
+const getSeenRelays = (context?: ProjectionContext): readonly string[] =>
+  context?.seenRelays ?? [];
+
+export const projectEventRow = (
+  event: NostrEvent,
+  context?: ProjectionContext,
+): NostrEventRow => ({
+  id: event.id,
+  pubkey: event.pubkey,
+  kind: event.kind,
+  createdAt: event.created_at,
+  raw: event,
+  seenRelays: getSeenRelays(context),
+  receivedAt: getReceivedAt(context),
+});
+
+const getString = (metadata: Record<string, unknown>, key: string) => {
+  const value = metadata[key];
+  return typeof value === "string" ? value : undefined;
+};
+
+const parseMetadata = (content: string): Record<string, unknown> => {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+};
+
+export const projectProfileRow = (
+  event: NostrEvent,
+  context?: ProjectionContext,
+): NostrProfileRow | undefined => {
+  if (event.kind !== 0) {
+    return undefined;
+  }
+
+  const metadata = parseMetadata(event.content);
+
+  return {
+    pubkey: event.pubkey,
+    name: getString(metadata, "name"),
+    displayName:
+      getString(metadata, "display_name") ?? getString(metadata, "displayName"),
+    about: getString(metadata, "about"),
+    picture: getString(metadata, "picture"),
+    nip05: getString(metadata, "nip05"),
+    lud16: getString(metadata, "lud16"),
+    sourceEventId: event.id,
+    updatedAt: event.created_at,
+    receivedAt: getReceivedAt(context),
+    seenRelays: getSeenRelays(context),
+  };
+};
+
+export const shouldReplaceProfileRow = (
+  next: NostrProfileRow | undefined,
+  current: NostrProfileRow | undefined,
+): boolean => {
+  if (!next) {
+    return false;
+  }
+  if (!current) {
+    return true;
+  }
+
+  return next.updatedAt > current.updatedAt;
+};

--- a/src/core/db/projectors/profile.ts
+++ b/src/core/db/projectors/profile.ts
@@ -1,28 +1,12 @@
 import type { NostrEvent } from "nostr-tools";
-import type {
-  NostrEventRow,
-  NostrProfileRow,
-  ProjectionContext,
-} from "../types";
+import { shouldReplaceEvent } from "../../nostr/replaceable";
+import type { NostrProfileRow, ProjectionContext } from "../types";
 
 const getReceivedAt = (context?: ProjectionContext): number =>
   context?.receivedAt ?? Date.now();
 
 const getSeenRelays = (context?: ProjectionContext): readonly string[] =>
   context?.seenRelays ?? [];
-
-export const projectEventRow = (
-  event: NostrEvent,
-  context?: ProjectionContext,
-): NostrEventRow => ({
-  id: event.id,
-  pubkey: event.pubkey,
-  kind: event.kind,
-  createdAt: event.created_at,
-  raw: event,
-  seenRelays: getSeenRelays(context),
-  receivedAt: getReceivedAt(context),
-});
 
 const getString = (metadata: Record<string, unknown>, key: string) => {
   const value = metadata[key];
@@ -66,6 +50,16 @@ export const projectProfileRow = (
   };
 };
 
+const profileRowSourceEvent = (row: NostrProfileRow): NostrEvent => ({
+  id: row.sourceEventId,
+  pubkey: row.pubkey,
+  kind: 0,
+  created_at: row.updatedAt,
+  tags: [],
+  content: "",
+  sig: "",
+});
+
 export const shouldReplaceProfileRow = (
   next: NostrProfileRow | undefined,
   current: NostrProfileRow | undefined,
@@ -77,5 +71,8 @@ export const shouldReplaceProfileRow = (
     return true;
   }
 
-  return next.updatedAt > current.updatedAt;
+  return shouldReplaceEvent(
+    profileRowSourceEvent(next),
+    profileRowSourceEvent(current),
+  );
 };

--- a/src/core/db/types.ts
+++ b/src/core/db/types.ts
@@ -1,0 +1,66 @@
+import type { Collection, LocalOnlyCollectionUtils } from "@tanstack/db";
+import type { NostrEvent } from "nostr-tools";
+import type { NostrEventQuery, RelayUrl } from "../repository/nostr-repository";
+
+export type NostrEventRow = {
+  id: string;
+  pubkey: string;
+  kind: number;
+  createdAt: number;
+  raw: NostrEvent;
+  seenRelays: readonly RelayUrl[];
+  receivedAt: number;
+};
+
+export type NostrProfileRow = {
+  pubkey: string;
+  name?: string;
+  displayName?: string;
+  about?: string;
+  picture?: string;
+  nip05?: string;
+  lud16?: string;
+  sourceEventId: string;
+  updatedAt: number;
+  receivedAt: number;
+  seenRelays: readonly RelayUrl[];
+};
+
+export type NostrQueryStatus = "idle" | "loading" | "complete" | "error";
+
+export type NostrQueryStateRow = {
+  id: string;
+  filter: NostrEventQuery;
+  status: NostrQueryStatus;
+  updatedAt: number;
+  error?: string;
+};
+
+export type NostrCollections = {
+  events: Collection<
+    NostrEventRow,
+    string,
+    LocalOnlyCollectionUtils,
+    never,
+    NostrEventRow
+  >;
+  profiles: Collection<
+    NostrProfileRow,
+    string,
+    LocalOnlyCollectionUtils,
+    never,
+    NostrProfileRow
+  >;
+  queryStates: Collection<
+    NostrQueryStateRow,
+    string,
+    LocalOnlyCollectionUtils,
+    never,
+    NostrQueryStateRow
+  >;
+};
+
+export type ProjectionContext = {
+  receivedAt?: number;
+  seenRelays?: readonly RelayUrl[];
+};

--- a/src/core/nostr/replaceable.test.ts
+++ b/src/core/nostr/replaceable.test.ts
@@ -1,0 +1,71 @@
+import type { NostrEvent } from "nostr-tools";
+import { describe, expect, test } from "vitest";
+import {
+  getReplaceableEventKey,
+  isParameterizedReplaceableKind,
+  isRegularReplaceableKind,
+  shouldReplaceEvent,
+} from "./replaceable";
+
+const event = (
+  overrides: Partial<NostrEvent> & { id: string },
+): NostrEvent => ({
+  id: overrides.id,
+  pubkey: overrides.pubkey ?? "pubkey-a",
+  created_at: overrides.created_at ?? 100,
+  kind: overrides.kind ?? 1,
+  tags: overrides.tags ?? [],
+  content: overrides.content ?? "",
+  sig: overrides.sig ?? `${overrides.id}-sig`,
+});
+
+describe("replaceable Nostr event helpers", () => {
+  test("detects regular and parameterized replaceable kind ranges", () => {
+    expect(isRegularReplaceableKind(0)).toBe(true);
+    expect(isRegularReplaceableKind(3)).toBe(true);
+    expect(isRegularReplaceableKind(10_000)).toBe(true);
+    expect(isRegularReplaceableKind(19_999)).toBe(true);
+    expect(isRegularReplaceableKind(1)).toBe(false);
+    expect(isRegularReplaceableKind(30_000)).toBe(false);
+
+    expect(isParameterizedReplaceableKind(30_000)).toBe(true);
+    expect(isParameterizedReplaceableKind(39_999)).toBe(true);
+    expect(isParameterizedReplaceableKind(0)).toBe(false);
+    expect(isParameterizedReplaceableKind(40_000)).toBe(false);
+  });
+
+  test("builds stable replacement keys for replaceable events", () => {
+    expect(
+      getReplaceableEventKey(
+        event({ id: "profile", kind: 0, pubkey: "alice" }),
+      ),
+    ).toEqual("0:alice");
+
+    expect(
+      getReplaceableEventKey(
+        event({
+          id: "article",
+          kind: 30_023,
+          pubkey: "alice",
+          tags: [["d", "hello-world"]],
+        }),
+      ),
+    ).toEqual("30023:alice:hello-world");
+
+    expect(
+      getReplaceableEventKey(event({ id: "note", kind: 1 })),
+    ).toBeUndefined();
+  });
+
+  test("prefers newer replaceable events and uses id tie-breaker for deterministic equal timestamps", () => {
+    const oldEvent = event({ id: "aaa", kind: 0, created_at: 100 });
+    const newEvent = event({ id: "bbb", kind: 0, created_at: 200 });
+    const sameTimeLowerId = event({ id: "aaa", kind: 0, created_at: 200 });
+    const sameTimeHigherId = event({ id: "ccc", kind: 0, created_at: 200 });
+
+    expect(shouldReplaceEvent(newEvent, oldEvent)).toBe(true);
+    expect(shouldReplaceEvent(oldEvent, newEvent)).toBe(false);
+    expect(shouldReplaceEvent(sameTimeHigherId, newEvent)).toBe(true);
+    expect(shouldReplaceEvent(sameTimeLowerId, newEvent)).toBe(false);
+  });
+});

--- a/src/core/nostr/replaceable.ts
+++ b/src/core/nostr/replaceable.ts
@@ -1,0 +1,54 @@
+import type { NostrEvent } from "nostr-tools";
+
+export const isRegularReplaceableKind = (kind: number): boolean =>
+  kind === 0 || kind === 3 || (kind >= 10_000 && kind < 20_000);
+
+export const isParameterizedReplaceableKind = (kind: number): boolean =>
+  kind >= 30_000 && kind < 40_000;
+
+export const getRegularReplaceableEventKey = (
+  kind: number,
+  pubkey: string,
+): string => `${kind}:${pubkey}`;
+
+export const getParameterizedReplaceableEventKey = (
+  kind: number,
+  pubkey: string,
+  d: string,
+): string => `${kind}:${pubkey}:${d}`;
+
+const getDTagValue = (event: NostrEvent): string | undefined => {
+  for (const tag of event.tags) {
+    if (tag[0] === "d") {
+      return tag[1];
+    }
+  }
+
+  return undefined;
+};
+
+export const getReplaceableEventKey = (
+  event: NostrEvent,
+): string | undefined => {
+  if (isRegularReplaceableKind(event.kind)) {
+    return getRegularReplaceableEventKey(event.kind, event.pubkey);
+  }
+
+  if (isParameterizedReplaceableKind(event.kind)) {
+    const d = getDTagValue(event) ?? "";
+    return getParameterizedReplaceableEventKey(event.kind, event.pubkey, d);
+  }
+
+  return undefined;
+};
+
+export const shouldReplaceEvent = (
+  next: NostrEvent,
+  current: NostrEvent,
+): boolean => {
+  if (next.created_at !== current.created_at) {
+    return next.created_at > current.created_at;
+  }
+
+  return next.id > current.id;
+};

--- a/src/core/repository/memory-repository.test.ts
+++ b/src/core/repository/memory-repository.test.ts
@@ -126,6 +126,26 @@ describe("MemoryNostrRepository", () => {
     ).resolves.toEqual(otherList);
   });
 
+  test("indexes parameterized replaceable events with a missing d tag under the empty d value", async () => {
+    const repository = new MemoryNostrRepository();
+    const eventWithoutD = event({
+      id: "without-d",
+      kind: 30000,
+      pubkey: "alice",
+      created_at: 100,
+      tags: [],
+    });
+
+    await repository.putEvent({
+      event: eventWithoutD,
+      relay: "wss://relay.example",
+    });
+
+    await expect(
+      repository.getParameterizedReplaceable(30000, "alice", ""),
+    ).resolves.toEqual(eventWithoutD);
+  });
+
   test("queries events by ids, authors, kinds, and tag filters", async () => {
     const repository = new MemoryNostrRepository();
     const aliceNote = event({

--- a/src/core/repository/memory-repository.ts
+++ b/src/core/repository/memory-repository.ts
@@ -1,4 +1,11 @@
 import type { NostrEvent } from "nostr-tools";
+import {
+  getParameterizedReplaceableEventKey,
+  getRegularReplaceableEventKey,
+  getReplaceableEventKey,
+  isParameterizedReplaceableKind,
+  shouldReplaceEvent,
+} from "../nostr/replaceable";
 import type {
   NostrEventQuery,
   NostrRepository,
@@ -8,36 +15,10 @@ import type {
   StoredNostrEvent,
 } from "./nostr-repository";
 
-const parameterizedReplaceableKindStart = 30_000;
-const parameterizedReplaceableKindEnd = 39_999;
-
-const regularReplaceableKinds = new Set([0, 3]);
-
-const isRegularReplaceableKind = (kind: number) =>
-  regularReplaceableKinds.has(kind) || (kind >= 10_000 && kind < 20_000);
-
-const isParameterizedReplaceableKind = (kind: number) =>
-  kind >= parameterizedReplaceableKindStart &&
-  kind <= parameterizedReplaceableKindEnd;
-
-const getDTag = (event: NostrEvent) =>
-  event.tags.find((tag) => tag[0] === "d")?.[1] ?? "";
-
-const regularReplaceableKey = (kind: number, pubkey: string) =>
-  `${kind}:${pubkey}`;
-
-const parameterizedReplaceableKey = (kind: number, pubkey: string, d: string) =>
-  `${kind}:${pubkey}:${d}`;
-
-const isNewer = (candidate: NostrEvent, current: NostrEvent | undefined) => {
-  if (!current) {
-    return true;
-  }
-  if (candidate.created_at !== current.created_at) {
-    return candidate.created_at > current.created_at;
-  }
-  return candidate.id > current.id;
-};
+const shouldReplaceIndexedEvent = (
+  candidate: NostrEvent,
+  current: NostrEvent | undefined,
+) => !current || shouldReplaceEvent(candidate, current);
 
 const eventMatchesQuery = (event: NostrEvent, query: NostrEventQuery) => {
   if (query.ids && !query.ids.includes(event.id)) {
@@ -121,7 +102,9 @@ export class MemoryNostrRepository implements NostrRepository {
     kind: number,
     pubkey: string,
   ): Promise<NostrEvent | undefined> {
-    const id = this.#latestReplaceable.get(regularReplaceableKey(kind, pubkey));
+    const id = this.#latestReplaceable.get(
+      getRegularReplaceableEventKey(kind, pubkey),
+    );
     return id ? this.#events.get(id)?.event : undefined;
   }
 
@@ -131,7 +114,7 @@ export class MemoryNostrRepository implements NostrRepository {
     d: string,
   ): Promise<NostrEvent | undefined> {
     const id = this.#latestParameterizedReplaceable.get(
-      parameterizedReplaceableKey(kind, pubkey, d),
+      getParameterizedReplaceableEventKey(kind, pubkey, d),
     );
     return id ? this.#events.get(id)?.event : undefined;
   }
@@ -144,27 +127,18 @@ export class MemoryNostrRepository implements NostrRepository {
   }
 
   #indexReplaceable(event: NostrEvent) {
-    if (isRegularReplaceableKind(event.kind)) {
-      const key = regularReplaceableKey(event.kind, event.pubkey);
-      const current = this.#eventForIndexedId(this.#latestReplaceable.get(key));
-      if (isNewer(event, current)) {
-        this.#latestReplaceable.set(key, event.id);
-      }
+    const key = getReplaceableEventKey(event);
+    if (!key) {
       return;
     }
 
-    if (isParameterizedReplaceableKind(event.kind)) {
-      const key = parameterizedReplaceableKey(
-        event.kind,
-        event.pubkey,
-        getDTag(event),
-      );
-      const current = this.#eventForIndexedId(
-        this.#latestParameterizedReplaceable.get(key),
-      );
-      if (isNewer(event, current)) {
-        this.#latestParameterizedReplaceable.set(key, event.id);
-      }
+    const index = isParameterizedReplaceableKind(event.kind)
+      ? this.#latestParameterizedReplaceable
+      : this.#latestReplaceable;
+    const current = this.#eventForIndexedId(index.get(key));
+
+    if (shouldReplaceIndexedEvent(event, current)) {
+      index.set(key, event.id);
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds `@tanstack/db` and isolated local-only read-model collections for Nostr events, profiles, and query states.
- Adds row types for near-raw event rows, projected kind:0 profile rows, query state rows, and projection context metadata.
- Adds initial projectors for raw events and kind:0 profile metadata, including newer-profile replacement checks.

## Test Plan
- [x] `pnpm exec tsc -b`
- [x] `pnpm run check`
- [x] `pnpm test -- --run src/core/db/collections.test.ts`
- [x] `pnpm test -- --run`
- [x] `pnpm run build`

## Review Focus
- Please check that TanStack DB is only introduced as the UI read-model layer; the raw Nostr event remains stored on `NostrEventRow` and repository ownership is not moved into DB collections.
- Please check whether the initial `events`, `profiles`, and `queryStates` row shapes are sufficient for the next repository-to-collection projection PR without coupling to Solid UI.
- Please check the kind:0 profile projection and replacement rule; this PR intentionally keeps it minimal and does not yet implement the full projection pipeline.

Linear: EYE-95

Note: I attempted the independent pre-commit reviewer twice, but the upstream provider returned HTTP 429 both times. Static diff checks and the validation commands above passed locally.
