### PR TITLE
feat: project repository events to collections

### DIFF
--- a/src/core/db/projectors/project-event.test.ts
+++ b/src/core/db/projectors/project-event.test.ts
@@ -1,0 +1,124 @@
+import type { NostrEvent } from "nostr-tools";
+import { describe, expect, test } from "vitest";
+import { createNostrCollections } from "../collections";
+import { projectRepositoryEvent } from "./project-event";
+
+const event = (
+  overrides: Partial<NostrEvent> & { id: string },
+): NostrEvent => ({
+  id: overrides.id,
+  pubkey: overrides.pubkey ?? "pubkey-a",
+  created_at: overrides.created_at ?? 100,
+  kind: overrides.kind ?? 1,
+  tags: overrides.tags ?? [],
+  content: overrides.content ?? "",
+  sig: overrides.sig ?? `${overrides.id}-sig`,
+});
+
+describe("repository event projection", () => {
+  test("upserts a repository event into the event collection", async () => {
+    const collections = createNostrCollections();
+    const note = event({ id: "event-1", content: "hello" });
+
+    await projectRepositoryEvent(collections, note, {
+      receivedAt: 1_000,
+      seenRelays: ["wss://relay-a.example"],
+    });
+
+    expect(collections.events.get("event-1")).toMatchObject({
+      id: "event-1",
+      raw: note,
+      receivedAt: 1_000,
+      seenRelays: ["wss://relay-a.example"],
+    });
+  });
+
+  test("merges seen relay metadata for duplicate relay events without duplicating rows", async () => {
+    const collections = createNostrCollections();
+    const note = event({ id: "event-1", content: "hello" });
+
+    await projectRepositoryEvent(collections, note, {
+      receivedAt: 1_000,
+      seenRelays: ["wss://relay-a.example", "wss://relay-b.example"],
+    });
+    await projectRepositoryEvent(collections, note, {
+      receivedAt: 1_001,
+      seenRelays: ["wss://relay-b.example", "wss://relay-c.example"],
+    });
+
+    expect(collections.events.get("event-1")).toMatchObject({
+      id: "event-1",
+      receivedAt: 1_001,
+      seenRelays: [
+        "wss://relay-a.example",
+        "wss://relay-b.example",
+        "wss://relay-c.example",
+      ],
+    });
+    expect(collections.events.size).toBe(1);
+  });
+
+  test("projects kind 0 metadata and ignores older profile events", async () => {
+    const collections = createNostrCollections();
+    const newerProfile = event({
+      id: "profile-new",
+      kind: 0,
+      pubkey: "alice",
+      created_at: 200,
+      content: JSON.stringify({ name: "new-alice" }),
+    });
+    const olderProfile = event({
+      id: "profile-old",
+      kind: 0,
+      pubkey: "alice",
+      created_at: 100,
+      content: JSON.stringify({ name: "old-alice" }),
+    });
+
+    await projectRepositoryEvent(collections, newerProfile, {
+      receivedAt: 1_000,
+      seenRelays: ["wss://relay-a.example"],
+    });
+    await projectRepositoryEvent(collections, olderProfile, {
+      receivedAt: 1_001,
+      seenRelays: ["wss://relay-b.example"],
+    });
+
+    expect(collections.profiles.get("alice")).toMatchObject({
+      pubkey: "alice",
+      name: "new-alice",
+      sourceEventId: "profile-new",
+      updatedAt: 200,
+      seenRelays: ["wss://relay-a.example"],
+    });
+    expect(collections.events.size).toBe(2);
+  });
+
+  test("is idempotent when the same repository event is projected more than once", async () => {
+    const collections = createNostrCollections();
+    const profile = event({
+      id: "profile-1",
+      kind: 0,
+      pubkey: "alice",
+      created_at: 100,
+      content: JSON.stringify({ name: "alice" }),
+    });
+
+    await projectRepositoryEvent(collections, profile, {
+      receivedAt: 1_000,
+      seenRelays: ["wss://relay-a.example"],
+    });
+    await projectRepositoryEvent(collections, profile, {
+      receivedAt: 1_001,
+      seenRelays: ["wss://relay-b.example"],
+    });
+
+    expect(collections.events.size).toBe(1);
+    expect(collections.profiles.size).toBe(1);
+    expect(collections.profiles.get("alice")).toMatchObject({
+      name: "alice",
+      receivedAt: 1_001,
+      seenRelays: ["wss://relay-a.example", "wss://relay-b.example"],
+    });
+  });
+});

--- a/src/core/db/projectors/project-event.ts
+++ b/src/core/db/projectors/project-event.ts
@@ -1,0 +1,91 @@
+import type { NostrEvent } from "nostr-tools";
+import type { NostrCollections, ProjectionContext } from "../types";
+import { projectEventRow } from "./event";
+import { projectProfileRow, shouldReplaceProfileRow } from "./profile";
+
+const persist = async <
+  TTransaction extends { isPersisted: { promise: Promise<unknown> } },
+>(
+  transaction: TTransaction,
+) => {
+  await transaction.isPersisted.promise;
+};
+
+const mergeSeenRelays = (
+  current: readonly string[],
+  next: readonly string[],
+): string[] => [...new Set([...current, ...next])];
+
+const upsertEventRow = async (
+  collections: NostrCollections,
+  event: NostrEvent,
+  context?: ProjectionContext,
+) => {
+  const row = projectEventRow(event, context);
+  const current = collections.events.get(row.id);
+
+  if (current) {
+    await persist(
+      collections.events.update(row.id, (draft) => {
+        draft.pubkey = row.pubkey;
+        draft.kind = row.kind;
+        draft.createdAt = row.createdAt;
+        draft.raw = row.raw;
+        draft.seenRelays = mergeSeenRelays(current.seenRelays, row.seenRelays);
+        draft.receivedAt = row.receivedAt;
+      }),
+    );
+    return;
+  }
+
+  await persist(collections.events.insert(row));
+};
+
+const upsertProfileRow = async (
+  collections: NostrCollections,
+  event: NostrEvent,
+  context?: ProjectionContext,
+) => {
+  const row = projectProfileRow(event, context);
+
+  if (!row) {
+    return;
+  }
+
+  const current = collections.profiles.get(row.pubkey);
+
+  if (!shouldReplaceProfileRow(row, current)) {
+    if (current?.sourceEventId !== row.sourceEventId) {
+      return;
+    }
+  }
+
+  if (current) {
+    await persist(
+      collections.profiles.update(row.pubkey, (draft) => {
+        draft.name = row.name;
+        draft.displayName = row.displayName;
+        draft.about = row.about;
+        draft.picture = row.picture;
+        draft.nip05 = row.nip05;
+        draft.lud16 = row.lud16;
+        draft.sourceEventId = row.sourceEventId;
+        draft.updatedAt = row.updatedAt;
+        draft.receivedAt = row.receivedAt;
+        draft.seenRelays = mergeSeenRelays(current.seenRelays, row.seenRelays);
+      }),
+    );
+    return;
+  }
+
+  await persist(collections.profiles.insert(row));
+};
+
+export const projectRepositoryEvent = async (
+  collections: NostrCollections,
+  event: NostrEvent,
+  context?: ProjectionContext,
+): Promise<void> => {
+  await upsertEventRow(collections, event, context);
+  await upsertProfileRow(collections, event, context);
+};


### PR DESCRIPTION
## Summary

- add `projectRepositoryEvent` as the repository-to-TanStack DB projection entrypoint
- upsert raw event rows into the event collection while merging `seenRelays`
- project kind:0 metadata into the profile collection and keep newer profile events authoritative
- preserve idempotency for duplicate/current events while still merging relay metadata

## Validation

- `pnpm test -- --run src/core/db/projectors/project-event.test.ts`
- `pnpm run build`
- `pnpm test -- --run`
- `pnpm run check`

## Review Focus

- Verify the projection boundary stays read-model-only and does not replace the repository as raw event source of truth.
- Check duplicate event/profile projection semantics, especially `seenRelays` merge behavior.
- Confirm older kind:0 profile events cannot overwrite newer profile read model rows.

Linear: EYE-96
