### PR TITLE
feat: route useEventByID through v1 core

### DIFF
--- a/src/core/solid/use-event.test.tsx
+++ b/src/core/solid/use-event.test.tsx
@@ -1,0 +1,118 @@
+import type { NostrEvent } from "nostr-tools";
+import { createRoot } from "solid-js";
+import { describe, expect, test, vi } from "vitest";
+import { projectRepositoryEvent } from "../db/projectors/project-event";
+import type { NostrCollections } from "../db/types";
+import type { NostrCoreQueryClient } from "../query/query-client";
+import { MemoryNostrRepository } from "../repository/memory-repository";
+import type { NostrRepository } from "../repository/nostr-repository";
+import { NostrCoreProvider, createNostrCore } from "./provider";
+import { useCoreEventByID } from "./use-event";
+
+const createEvent = (overrides: Partial<NostrEvent> = {}): NostrEvent => ({
+  id: "event-1",
+  pubkey: "pubkey-1",
+  kind: 1,
+  content: "hello",
+  tags: [],
+  created_at: 1,
+  sig: "sig",
+  ...overrides,
+});
+
+const createCore = (repository: NostrRepository) => {
+  const ensured: Array<{ id: string; relays?: readonly string[] }> = [];
+  const queryClient: NostrCoreQueryClient = {
+    async ensureEvent(options) {
+      ensured.push(options);
+      return repository.getEvent(options.id);
+    },
+    async ensureProfile() {
+      return undefined;
+    },
+    dispose: vi.fn(),
+  };
+
+  return {
+    ensured,
+    core: createNostrCore({
+      rxNostr: {} as Parameters<typeof createNostrCore>[0]["rxNostr"],
+      repository,
+      queryClient,
+    }),
+  };
+};
+
+describe("useCoreEventByID", () => {
+  test("returns cached repository events through the legacy cache shape", async () => {
+    const repository = new MemoryNostrRepository();
+    const event = createEvent();
+    await repository.putEvent({ event, relay: "wss://relay.example" });
+    const { core, ensured } = createCore(repository);
+
+    await new Promise<void>((resolve) => {
+      createRoot((dispose) => {
+        NostrCoreProvider({
+          core,
+          get children() {
+            const data = useCoreEventByID(() => event.id);
+            queueMicrotask(async () => {
+              await vi.waitFor(() => {
+                expect(data().data?.raw).toBe(event);
+              });
+              expect(ensured).toEqual([{ id: event.id, relays: undefined }]);
+              dispose();
+              resolve();
+            });
+            return null;
+          },
+        });
+      });
+    });
+  });
+
+  test("subscribes to the event collection and updates when projection inserts the event", async () => {
+    const repository = new MemoryNostrRepository();
+    const { core, ensured } = createCore(repository);
+    const event = createEvent();
+
+    await new Promise<void>((resolve) => {
+      createRoot((dispose) => {
+        NostrCoreProvider({
+          core,
+          get children() {
+            const data = useCoreEventByID(
+              () => event.id,
+              () => ["wss://relay.example"],
+            );
+            queueMicrotask(async () => {
+              await vi.waitFor(() => {
+                expect(ensured).toEqual([
+                  { id: event.id, relays: ["wss://relay.example"] },
+                ]);
+              });
+              expect(data().data).toBeUndefined();
+
+              await projectRepositoryEvent(
+                core.collections as NostrCollections,
+                event,
+                {
+                  receivedAt: 123,
+                  seenRelays: ["wss://relay.example"],
+                },
+              );
+
+              await vi.waitFor(() => {
+                expect(data().data?.raw).toBe(event);
+              });
+              expect(data().isFetching).toBe(false);
+              dispose();
+              resolve();
+            });
+            return null;
+          },
+        });
+      });
+    });
+  });
+});

--- a/src/core/solid/use-event.ts
+++ b/src/core/solid/use-event.ts
@@ -1,0 +1,102 @@
+import type { NostrEvent } from "nostr-tools";
+import { createEffect, createSignal, onCleanup } from "solid-js";
+import type { CacheDataBase } from "../../context/eventCache";
+import {
+  type ParsedEventPacket,
+  parseNostrEvent,
+} from "../../shared/libs/parser";
+import type { RelayUrl } from "../repository/nostr-repository";
+import { useNostrCore } from "./provider";
+
+const createCacheData = <T>(
+  data?: ParsedEventPacket<T>,
+  isFetching = false,
+): CacheDataBase<ParsedEventPacket<T>> => ({
+  data,
+  dataUpdatedAt: data ? Date.now() : 0,
+  isFetching,
+  isInvalidated: false,
+});
+
+const toParsedEventPacket = <T>(
+  event: NostrEvent,
+  relay?: RelayUrl,
+): ParsedEventPacket<T> => ({
+  from: relay ?? "",
+  raw: event,
+  parsed: parseNostrEvent(event) as T,
+});
+
+export const useCoreEventByID = <T = ReturnType<typeof parseNostrEvent>>(
+  id: () => string | undefined,
+  relays?: () => readonly RelayUrl[] | undefined,
+) => {
+  const core = useNostrCore();
+  const [cache, setCache] = createSignal<CacheDataBase<ParsedEventPacket<T>>>(
+    createCacheData<T>(),
+  );
+
+  const syncFromCollection = (eventId: string) => {
+    const row = core.collections.events.get(eventId);
+    if (!row) {
+      setCache((prev) => ({ ...prev, data: undefined }));
+      return undefined;
+    }
+
+    const data = toParsedEventPacket<T>(row.raw, row.seenRelays[0]);
+    setCache({
+      data,
+      dataUpdatedAt: row.receivedAt,
+      isFetching: false,
+      isInvalidated: false,
+    });
+    return data;
+  };
+
+  // Keep the legacy cache-shaped accessor synchronized with the v1 event collection
+  // and issue an id query through the core query client when the event is missing.
+  createEffect(() => {
+    const eventId = id();
+    if (!eventId) {
+      setCache(createCacheData<T>());
+      return;
+    }
+
+    const subscription = core.collections.events.subscribeChanges(
+      () => {
+        syncFromCollection(eventId);
+      },
+      { includeInitialState: true },
+    );
+
+    if (!syncFromCollection(eventId)) {
+      setCache((prev) => ({ ...prev, isFetching: true }));
+      void core.queryClient
+        .ensureEvent({ id: eventId, relays: relays?.() })
+        .then((event) => {
+          if (id() !== eventId) {
+            return;
+          }
+          if (event) {
+            setCache({
+              data: toParsedEventPacket<T>(event, relays?.()?.[0]),
+              dataUpdatedAt: Date.now(),
+              isFetching: false,
+              isInvalidated: false,
+            });
+            return;
+          }
+          setCache((prev) => ({ ...prev, isFetching: false }));
+        })
+        .catch(() => {
+          setCache((prev) => ({ ...prev, isFetching: false }));
+        });
+    }
+
+    onCleanup(() => {
+      subscription.unsubscribe();
+    });
+  });
+
+  return cache;
+};

--- a/src/shared/libs/query.ts
+++ b/src/shared/libs/query.ts
@@ -26,6 +26,7 @@ import {
 } from "../../context/eventCache";
 import { type SendingState, useLoading } from "../../context/loading";
 import { useRxNostr } from "../../context/rxNostr";
+import { useCoreEventByID } from "../../core/solid/use-event";
 import { genID } from "./id";
 import { mergeSimilarAndRemoveEmptyFilters } from "./mergeFilters";
 import {
@@ -308,33 +309,7 @@ export const cacheAndEmitRelatedEvent = (
 export const useEventByID = <T = ReturnType<typeof parseNostrEvent>>(
   id: () => string | undefined,
   relays?: () => string[] | undefined,
-) => {
-  const queryKey = () => ["event", id()];
-
-  const {
-    actions: { emit },
-  } = useRxNostr();
-
-  const emitter = () => {
-    const _id = id();
-    if (_id) {
-      const _relays = relays?.() ?? [];
-      emit(
-        { ids: [_id] },
-        _relays.length > 0
-          ? {
-              relays: _relays,
-            }
-          : undefined,
-      );
-    }
-  };
-
-  return createGetter<ParsedEventPacket<T>>(() => ({
-    queryKey: queryKey(),
-    emitter,
-  }));
-};
+) => useCoreEventByID<T>(id, relays);
 
 export const useFollowees = (pubkey: () => string | undefined) => {
   const queryKey = () => [kinds.Contacts, pubkey()];


### PR DESCRIPTION
## Summary

- add `useCoreEventByID` backed by the v1 core provider, repository query client, and event collection
- keep the legacy `useEventByID` export as a thin compatibility wrapper around the new core hook
- cover cached repository reads and collection projection updates with Solid hook tests

## Verification

- `pnpm test -- --run src/core/solid/use-event.test.tsx src/core/query/query-client.test.ts`
- `pnpm run build`
- `pnpm test -- --run`
- `pnpm run check`

## Notes

- Build still emits existing `nostr-login` eval warnings and large chunk warnings. These are existing dependency/bundle warnings and not introduced by this change.
