### PR TITLE
feat: route useProfile through v1 core

### DIFF
--- a/src/core/solid/use-profile.test.tsx
+++ b/src/core/solid/use-profile.test.tsx
@@ -1,0 +1,131 @@
+import { type NostrEvent, kinds } from "nostr-tools";
+import { createRoot } from "solid-js";
+import { describe, expect, test, vi } from "vitest";
+import { projectRepositoryEvent } from "../db/projectors/project-event";
+import type { NostrCollections } from "../db/types";
+import type { NostrCoreQueryClient } from "../query/query-client";
+import { MemoryNostrRepository } from "../repository/memory-repository";
+import type { NostrRepository } from "../repository/nostr-repository";
+import { NostrCoreProvider, createNostrCore } from "./provider";
+import { useCoreProfile } from "./use-profile";
+
+const createProfileEvent = (
+  overrides: Partial<NostrEvent> = {},
+): NostrEvent => ({
+  id: "profile-1",
+  pubkey: "pubkey-1",
+  kind: kinds.Metadata,
+  content: JSON.stringify({
+    name: "alice",
+    display_name: "Alice",
+    about: "hello",
+    picture: "https://example.com/alice.png",
+    nip05: "alice@example.com",
+    lud16: "alice@example.com",
+  }),
+  tags: [],
+  created_at: 1,
+  sig: "sig",
+  ...overrides,
+});
+
+const createCore = (repository: NostrRepository) => {
+  const ensured: Array<{ pubkey: string; relays?: readonly string[] }> = [];
+  const queryClient: NostrCoreQueryClient = {
+    async ensureEvent() {
+      return undefined;
+    },
+    async ensureProfile(options) {
+      ensured.push(options);
+      return repository.getLatestReplaceable(kinds.Metadata, options.pubkey);
+    },
+    dispose: vi.fn(),
+  };
+
+  return {
+    ensured,
+    core: createNostrCore({
+      rxNostr: {} as Parameters<typeof createNostrCore>[0]["rxNostr"],
+      repository,
+      queryClient,
+    }),
+  };
+};
+
+describe("useCoreProfile", () => {
+  test("returns cached repository profile metadata through the legacy cache shape", async () => {
+    const repository = new MemoryNostrRepository();
+    const event = createProfileEvent();
+    await repository.putEvent({ event, relay: "wss://relay.example" });
+    const { core, ensured } = createCore(repository);
+
+    await new Promise<void>((resolve) => {
+      createRoot((dispose) => {
+        NostrCoreProvider({
+          core,
+          get children() {
+            const data = useCoreProfile(() => event.pubkey);
+            queueMicrotask(async () => {
+              await vi.waitFor(() => {
+                expect(data().data?.raw).toBe(event);
+                expect(data().data?.parsed.name).toBe("alice");
+              });
+              expect(ensured).toEqual([
+                { pubkey: event.pubkey, relays: undefined },
+              ]);
+              dispose();
+              resolve();
+            });
+            return null;
+          },
+        });
+      });
+    });
+  });
+
+  test("subscribes to the profile collection and updates when projection inserts metadata", async () => {
+    const repository = new MemoryNostrRepository();
+    const { core, ensured } = createCore(repository);
+    const event = createProfileEvent();
+
+    await new Promise<void>((resolve) => {
+      createRoot((dispose) => {
+        NostrCoreProvider({
+          core,
+          get children() {
+            const data = useCoreProfile(
+              () => event.pubkey,
+              () => ["wss://relay.example"],
+            );
+            queueMicrotask(async () => {
+              await vi.waitFor(() => {
+                expect(ensured).toEqual([
+                  { pubkey: event.pubkey, relays: ["wss://relay.example"] },
+                ]);
+              });
+              expect(data().data).toBeUndefined();
+
+              await projectRepositoryEvent(
+                core.collections as NostrCollections,
+                event,
+                {
+                  receivedAt: 123,
+                  seenRelays: ["wss://relay.example"],
+                },
+              );
+
+              await vi.waitFor(() => {
+                expect(data().data?.raw.id).toBe(event.id);
+                expect(data().data?.parsed.display_name).toBe("Alice");
+              });
+              expect(data().isFetching).toBe(false);
+              dispose();
+              resolve();
+            });
+            return null;
+          },
+        });
+      });
+    });
+  });
+});

--- a/src/core/solid/use-profile.ts
+++ b/src/core/solid/use-profile.ts
@@ -1,0 +1,124 @@
+import { type NostrEvent, kinds } from "nostr-tools";
+import { createEffect, createSignal, onCleanup } from "solid-js";
+import type { CacheDataBase } from "../../context/eventCache";
+import {
+  type ParsedEventPacket,
+  parseNostrEvent,
+} from "../../shared/libs/parser";
+import type { Metadata } from "../../shared/libs/parser/0_metadata";
+import type { NostrProfileRow } from "../db/types";
+import type { RelayUrl } from "../repository/nostr-repository";
+import { useNostrCore } from "./provider";
+
+const createCacheData = <T>(
+  data?: ParsedEventPacket<T>,
+  isFetching = false,
+): CacheDataBase<ParsedEventPacket<T>> => ({
+  data,
+  dataUpdatedAt: data ? Date.now() : 0,
+  isFetching,
+  isInvalidated: false,
+});
+
+const profileRowToEvent = (row: NostrProfileRow): NostrEvent => ({
+  id: row.sourceEventId,
+  pubkey: row.pubkey,
+  kind: kinds.Metadata,
+  content: JSON.stringify({
+    name: row.name,
+    display_name: row.displayName,
+    about: row.about,
+    picture: row.picture,
+    nip05: row.nip05,
+    lud16: row.lud16,
+  }),
+  tags: [],
+  created_at: row.updatedAt,
+  sig: "",
+});
+
+const toParsedProfilePacket = <T>(
+  event: NostrEvent,
+  relay?: RelayUrl,
+): ParsedEventPacket<T> => ({
+  from: relay ?? "",
+  raw: event,
+  parsed: parseNostrEvent(event) as T,
+});
+
+export const useCoreProfile = <T = Metadata>(
+  pubkey: () => string | undefined,
+  relays?: () => readonly RelayUrl[] | undefined,
+) => {
+  const core = useNostrCore();
+  const [cache, setCache] = createSignal<CacheDataBase<ParsedEventPacket<T>>>(
+    createCacheData<T>(),
+  );
+
+  const syncFromCollection = (profilePubkey: string) => {
+    const row = core.collections.profiles.get(profilePubkey);
+    if (!row) {
+      setCache((prev) => ({ ...prev, data: undefined }));
+      return undefined;
+    }
+
+    const data = toParsedProfilePacket<T>(
+      profileRowToEvent(row),
+      row.seenRelays[0],
+    );
+    setCache({
+      data,
+      dataUpdatedAt: row.receivedAt,
+      isFetching: false,
+      isInvalidated: false,
+    });
+    return data;
+  };
+
+  // Keep the legacy cache-shaped accessor synchronized with the v1 profile collection
+  // and issue a profile metadata query through the core query client when missing.
+  createEffect(() => {
+    const profilePubkey = pubkey();
+    if (!profilePubkey) {
+      setCache(createCacheData<T>());
+      return;
+    }
+
+    const subscription = core.collections.profiles.subscribeChanges(
+      () => {
+        syncFromCollection(profilePubkey);
+      },
+      { includeInitialState: true },
+    );
+
+    if (!syncFromCollection(profilePubkey)) {
+      setCache((prev) => ({ ...prev, isFetching: true }));
+      void core.queryClient
+        .ensureProfile({ pubkey: profilePubkey, relays: relays?.() })
+        .then((event) => {
+          if (pubkey() !== profilePubkey) {
+            return;
+          }
+          if (event) {
+            setCache({
+              data: toParsedProfilePacket<T>(event, relays?.()?.[0]),
+              dataUpdatedAt: Date.now(),
+              isFetching: false,
+              isInvalidated: false,
+            });
+            return;
+          }
+          setCache((prev) => ({ ...prev, isFetching: false }));
+        })
+        .catch(() => {
+          setCache((prev) => ({ ...prev, isFetching: false }));
+        });
+    }
+
+    onCleanup(() => {
+      subscription.unsubscribe();
+    });
+  });
+
+  return cache;
+};

--- a/src/shared/libs/query.ts
+++ b/src/shared/libs/query.ts
@@ -27,6 +27,7 @@ import {
 import { type SendingState, useLoading } from "../../context/loading";
 import { useRxNostr } from "../../context/rxNostr";
 import { useCoreEventByID } from "../../core/solid/use-event";
+import { useCoreProfile } from "../../core/solid/use-profile";
 import { genID } from "./id";
 import { mergeSimilarAndRemoveEmptyFilters } from "./mergeFilters";
 import {
@@ -386,28 +387,8 @@ export const useFollowers = (pubkey: () => string | undefined) => {
   }));
 };
 
-export const useProfile = (pubkey: () => string | undefined) => {
-  const queryKey = () => [kinds.Metadata, pubkey()];
-
-  const {
-    actions: { emit },
-  } = useRxNostr();
-
-  const emitter = () => {
-    const _pubkey = pubkey();
-    if (_pubkey) {
-      emit({
-        kinds: [kinds.Metadata],
-        authors: [_pubkey],
-      });
-    }
-  };
-
-  return createGetter<ParsedEventPacket<Metadata>>(() => ({
-    queryKey: queryKey(),
-    emitter,
-  }));
-};
+export const useProfile = (pubkey: () => string | undefined) =>
+  useCoreProfile(pubkey);
 
 export const useReactionsOfEvent = (eventID: () => string | undefined) => {
   const queryKey = () => ["reactionsOf", eventID()];


### PR DESCRIPTION
## Summary

- add `useCoreProfile` backed by the v1 core provider, query client, and profile collection
- keep the legacy `useProfile` export as a thin compatibility wrapper around the new core hook
- add Solid hook coverage for cached profile metadata and live profile collection updates

## Validation

- `pnpm exec biome check --write src/core/solid/use-profile.ts src/core/solid/use-profile.test.tsx src/shared/libs/query.ts`
- `pnpm test -- --run src/core/solid/use-profile.test.tsx src/core/solid/use-event.test.tsx src/core/query/query-client.test.ts`
- `pnpm run build`
- `pnpm test -- --run`
- `pnpm run check`

## Notes

- The existing `nostr-login` eval warning and chunk-size warning still appear during build.
- Existing callers can continue importing `useProfile` from `src/shared/libs/query.ts`.
