### PR TITLE
feat: route relation hooks through v1 core

### DIFF
--- a/src/core/query/query-client.ts
+++ b/src/core/query/query-client.ts
@@ -1,7 +1,11 @@
 import type { NostrEvent } from "nostr-tools";
 import { projectRepositoryEvent } from "../db/projectors/project-event";
 import type { NostrCollections } from "../db/types";
-import type { NostrRepository, RelayUrl } from "../repository/nostr-repository";
+import type {
+  NostrEventQuery,
+  NostrRepository,
+  RelayUrl,
+} from "../repository/nostr-repository";
 import { subscribeToTransportEvents } from "../transport/rx-nostr-transport";
 import type { NostrSubscription, NostrTransport } from "../transport/transport";
 
@@ -15,9 +19,17 @@ export type EnsureProfileOptions = {
   relays?: readonly RelayUrl[];
 };
 
+export type EnsureEventRelationsOptions = {
+  query: NostrEventQuery;
+  relays?: readonly RelayUrl[];
+};
+
 export type NostrCoreQueryClient = {
   ensureEvent(options: EnsureEventOptions): Promise<NostrEvent | undefined>;
   ensureProfile(options: EnsureProfileOptions): Promise<NostrEvent | undefined>;
+  ensureEventRelations(
+    options: EnsureEventRelationsOptions,
+  ): Promise<NostrEvent[]>;
   dispose(): void;
 };
 
@@ -119,6 +131,27 @@ export const createNostrCoreQueryClient = ({
         mode: "backward",
       });
       return undefined;
+    },
+
+    async ensureEventRelations({ query, relays }) {
+      const cached = await repository.queryEvents(query);
+      subscribeAndEmit({
+        filters: {
+          ids: query.ids ? [...query.ids] : undefined,
+          authors: query.authors ? [...query.authors] : undefined,
+          kinds: query.kinds ? [...query.kinds] : undefined,
+          limit: query.limit,
+          ...Object.fromEntries(
+            Object.entries(query.tags ?? {}).map(([name, values]) => [
+              `#${name}`,
+              [...values],
+            ]),
+          ),
+        },
+        relays,
+        mode: "backward",
+      });
+      return cached;
     },
 
     dispose() {

--- a/src/core/solid/use-event-relations.test.tsx
+++ b/src/core/solid/use-event-relations.test.tsx
@@ -1,0 +1,168 @@
+import { type NostrEvent, kinds } from "nostr-tools";
+import { createRoot } from "solid-js";
+import { describe, expect, test, vi } from "vitest";
+import { projectRepositoryEvent } from "../db/projectors/project-event";
+import type { NostrCollections } from "../db/types";
+import type { NostrCoreQueryClient } from "../query/query-client";
+import { MemoryNostrRepository } from "../repository/memory-repository";
+import type {
+  NostrEventQuery,
+  NostrRepository,
+} from "../repository/nostr-repository";
+import { NostrCoreProvider, createNostrCore } from "./provider";
+import { useCoreEventRelations } from "./use-event-relations";
+
+const createEvent = (overrides: Partial<NostrEvent> = {}): NostrEvent => ({
+  id: "event-1",
+  pubkey: "pubkey-1",
+  kind: kinds.ShortTextNote,
+  content: "hello",
+  tags: [],
+  created_at: 1,
+  sig: "sig",
+  ...overrides,
+});
+
+const createCore = (repository: NostrRepository) => {
+  const ensuredRelations: Array<{
+    query: NostrEventQuery;
+    relays?: readonly string[];
+  }> = [];
+  const queryClient: NostrCoreQueryClient = {
+    async ensureEvent() {
+      return undefined;
+    },
+    async ensureProfile() {
+      return undefined;
+    },
+    async ensureEventRelations(options) {
+      ensuredRelations.push(options);
+      return repository.queryEvents(options.query);
+    },
+    dispose: vi.fn(),
+  };
+
+  return {
+    ensuredRelations,
+    core: createNostrCore({
+      rxNostr: {} as Parameters<typeof createNostrCore>[0]["rxNostr"],
+      repository,
+      queryClient,
+    }),
+  };
+};
+
+describe("useCoreEventRelations", () => {
+  test("returns cached matching relation events through the legacy array shape", async () => {
+    const repository = new MemoryNostrRepository();
+    const target = createEvent({ id: "target" });
+    const reaction = createEvent({
+      id: "reaction-1",
+      kind: kinds.Reaction,
+      tags: [
+        ["e", target.id],
+        ["p", target.pubkey],
+      ],
+      content: "+",
+      created_at: 10,
+    });
+    await repository.putEvent({
+      event: reaction,
+      relay: "wss://relay.example",
+    });
+    const { core, ensuredRelations } = createCore(repository);
+
+    await new Promise<void>((resolve) => {
+      createRoot((dispose) => {
+        NostrCoreProvider({
+          core,
+          get children() {
+            const data = useCoreEventRelations(
+              () => ({ kinds: [kinds.Reaction], tags: { e: [target.id] } }),
+              () => ["wss://relay.example"],
+            );
+            queueMicrotask(async () => {
+              await vi.waitFor(() => {
+                expect(data().data?.map((packet) => packet.raw.id)).toEqual([
+                  reaction.id,
+                ]);
+              });
+              expect(ensuredRelations).toEqual([
+                {
+                  query: { kinds: [kinds.Reaction], tags: { e: [target.id] } },
+                  relays: ["wss://relay.example"],
+                },
+              ]);
+              dispose();
+              resolve();
+            });
+            return null;
+          },
+        });
+      });
+    });
+  });
+
+  test("subscribes to the event collection and updates when a matching relation is projected", async () => {
+    const repository = new MemoryNostrRepository();
+    const { core, ensuredRelations } = createCore(repository);
+    const target = createEvent({ id: "target" });
+    const reply = createEvent({
+      id: "reply-1",
+      tags: [["e", target.id, "", "reply"]],
+      content: "reply",
+      created_at: 11,
+    });
+
+    await new Promise<void>((resolve) => {
+      createRoot((dispose) => {
+        NostrCoreProvider({
+          core,
+          get children() {
+            const data = useCoreEventRelations(() => ({
+              kinds: [kinds.ShortTextNote],
+              tags: { e: [target.id] },
+            }));
+            queueMicrotask(async () => {
+              await vi.waitFor(() => {
+                expect(ensuredRelations).toEqual([
+                  {
+                    query: {
+                      kinds: [kinds.ShortTextNote],
+                      tags: { e: [target.id] },
+                    },
+                    relays: undefined,
+                  },
+                ]);
+              });
+              expect(data().data).toEqual([]);
+
+              await repository.putEvent({
+                event: reply,
+                relay: "wss://relay.example",
+              });
+              await projectRepositoryEvent(
+                core.collections as NostrCollections,
+                reply,
+                {
+                  receivedAt: 123,
+                  seenRelays: ["wss://relay.example"],
+                },
+              );
+
+              await vi.waitFor(() => {
+                expect(data().data?.map((packet) => packet.raw.id)).toEqual([
+                  reply.id,
+                ]);
+              });
+              expect(data().isFetching).toBe(false);
+              dispose();
+              resolve();
+            });
+            return null;
+          },
+        });
+      });
+    });
+  });
+});

--- a/src/core/solid/use-event-relations.ts
+++ b/src/core/solid/use-event-relations.ts
@@ -1,0 +1,134 @@
+import type { NostrEvent } from "nostr-tools";
+import { createEffect, createSignal, onCleanup } from "solid-js";
+import type { CacheDataBase } from "../../context/eventCache";
+import {
+  type ParsedEventPacket,
+  parseNostrEvent,
+} from "../../shared/libs/parser";
+import type { NostrEventQuery, RelayUrl } from "../repository/nostr-repository";
+import { useNostrCore } from "./provider";
+
+const createCacheData = <T>(
+  data?: ParsedEventPacket<T>[],
+  isFetching = false,
+): CacheDataBase<ParsedEventPacket<T>[]> => ({
+  data,
+  dataUpdatedAt: data ? Date.now() : 0,
+  isFetching,
+  isInvalidated: false,
+});
+
+const toParsedEventPacket = <T>(
+  event: NostrEvent,
+  relay?: RelayUrl,
+): ParsedEventPacket<T> => ({
+  from: relay ?? "",
+  raw: event,
+  parsed: parseNostrEvent(event) as T,
+});
+
+const eventMatchesQuery = (event: NostrEvent, query: NostrEventQuery) => {
+  if (query.ids && !query.ids.includes(event.id)) {
+    return false;
+  }
+  if (query.authors && !query.authors.includes(event.pubkey)) {
+    return false;
+  }
+  if (query.kinds && !query.kinds.includes(event.kind)) {
+    return false;
+  }
+  if (query.tags) {
+    for (const [name, values] of Object.entries(query.tags)) {
+      const hasTagValue = event.tags.some(
+        (tag) =>
+          tag[0] === name && tag[1] !== undefined && values.includes(tag[1]),
+      );
+      if (!hasTagValue) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+export const useCoreEventRelations = <T = ReturnType<typeof parseNostrEvent>>(
+  query: () => NostrEventQuery | undefined,
+  relays?: () => readonly RelayUrl[] | undefined,
+) => {
+  const core = useNostrCore();
+  const [cache, setCache] = createSignal<CacheDataBase<ParsedEventPacket<T>[]>>(
+    createCacheData<T>(),
+  );
+  let requestVersion = 0;
+
+  const syncFromCollection = (currentQuery: NostrEventQuery) => {
+    const rows = [...core.collections.events.values()]
+      .filter((row) => eventMatchesQuery(row.raw, currentQuery))
+      .sort((a, b) => b.createdAt - a.createdAt || b.id.localeCompare(a.id))
+      .slice(0, currentQuery.limit);
+    const data = rows.map((row) =>
+      toParsedEventPacket<T>(row.raw, row.seenRelays[0]),
+    );
+    setCache({
+      data,
+      dataUpdatedAt:
+        rows.reduce((latest, row) => Math.max(latest, row.receivedAt), 0) ||
+        Date.now(),
+      isFetching: false,
+      isInvalidated: false,
+    });
+    return data;
+  };
+
+  // Keep a legacy array-shaped relation accessor synchronized with the v1 event collection
+  // and issue relation filters through the core query client instead of direct rx-nostr emits.
+  createEffect(() => {
+    const currentQuery = query();
+    const currentRelays = relays?.();
+    const currentRequestVersion = ++requestVersion;
+    if (!currentQuery) {
+      setCache(createCacheData<T>());
+      return;
+    }
+
+    const subscription = core.collections.events.subscribeChanges(
+      () => {
+        syncFromCollection(currentQuery);
+      },
+      { includeInitialState: true },
+    );
+
+    syncFromCollection(currentQuery);
+    setCache((prev) => ({ ...prev, isFetching: true }));
+    void core.queryClient
+      .ensureEventRelations({ query: currentQuery, relays: currentRelays })
+      .then((events) => {
+        if (requestVersion !== currentRequestVersion) {
+          return;
+        }
+        if (events.length > 0) {
+          setCache({
+            data: events.map((event) =>
+              toParsedEventPacket<T>(event, currentRelays?.[0]),
+            ),
+            dataUpdatedAt: Date.now(),
+            isFetching: false,
+            isInvalidated: false,
+          });
+          return;
+        }
+        setCache((prev) => ({ ...prev, isFetching: false }));
+      })
+      .catch(() => {
+        if (requestVersion === currentRequestVersion) {
+          setCache((prev) => ({ ...prev, isFetching: false }));
+        }
+      });
+
+    onCleanup(() => {
+      subscription.unsubscribe();
+    });
+  });
+
+  return cache;
+};

--- a/src/shared/libs/query.ts
+++ b/src/shared/libs/query.ts
@@ -27,6 +27,7 @@ import {
 import { type SendingState, useLoading } from "../../context/loading";
 import { useRxNostr } from "../../context/rxNostr";
 import { useCoreEventByID } from "../../core/solid/use-event";
+import { useCoreEventRelations } from "../../core/solid/use-event-relations";
 import { useCoreProfile } from "../../core/solid/use-profile";
 import { genID } from "./id";
 import { mergeSimilarAndRemoveEmptyFilters } from "./mergeFilters";
@@ -391,92 +392,39 @@ export const useProfile = (pubkey: () => string | undefined) =>
   useCoreProfile(pubkey);
 
 export const useReactionsOfEvent = (eventID: () => string | undefined) => {
-  const queryKey = () => ["reactionsOf", eventID()];
-
-  const {
-    actions: { emit },
-  } = useRxNostr();
-
-  const emitter = () => {
+  return useCoreEventRelations<Reaction>(() => {
     const _eventID = eventID();
-    if (_eventID) {
-      emit({
-        kinds: [kinds.Reaction],
-        "#e": [_eventID],
-      });
-    }
-  };
-
-  return createGetter<ParsedEventPacket<Reaction>[]>(() => ({
-    queryKey: queryKey(),
-    emitter,
-  }));
+    return _eventID
+      ? { kinds: [kinds.Reaction], tags: { e: [_eventID] } }
+      : undefined;
+  });
 };
 
 export const useRepostsOfEvent = (eventID: () => string | undefined) => {
-  const queryKey = () => ["repostsOf", eventID()];
-
-  const {
-    actions: { emit },
-  } = useRxNostr();
-  const emitter = () => {
+  return useCoreEventRelations<Repost>(() => {
     const _eventID = eventID();
-    if (_eventID) {
-      emit({
-        kinds: [kinds.Repost, kinds.GenericRepost],
-        "#e": [_eventID],
-      });
-    }
-  };
-
-  return createGetter<ParsedEventPacket<Repost>[]>(() => ({
-    queryKey: queryKey(),
-    emitter,
-  }));
+    return _eventID
+      ? { kinds: [kinds.Repost, kinds.GenericRepost], tags: { e: [_eventID] } }
+      : undefined;
+  });
 };
 
 export const useQuotesOfEvent = (eventID: () => string | undefined) => {
-  const queryKey = () => ["quotesOf", eventID()];
-
-  const {
-    actions: { emit },
-  } = useRxNostr();
-  const emitter = () => {
+  return useCoreEventRelations<ShortTextNote>(() => {
     const _eventID = eventID();
-    if (_eventID) {
-      emit({
-        kinds: [kinds.ShortTextNote],
-        "#q": [_eventID],
-      });
-    }
-  };
-
-  return createGetter<ParsedEventPacket<ShortTextNote>[]>(() => ({
-    queryKey: queryKey(),
-    emitter,
-  }));
+    return _eventID
+      ? { kinds: [kinds.ShortTextNote], tags: { q: [_eventID] } }
+      : undefined;
+  });
 };
 
 export const useRepliesOfEvent = (eventID: () => string | undefined) => {
-  const queryKey = () => ["repliesOf", eventID()];
-
-  const {
-    actions: { emit },
-  } = useRxNostr();
-  const emitter = () => {
+  return useCoreEventRelations<ShortTextNote>(() => {
     const _eventID = eventID();
-    if (_eventID) {
-      emit({
-        kinds: [kinds.ShortTextNote],
-        "#e": [_eventID],
-      });
-    }
-  };
-
-  return createGetter<ParsedEventPacket<ShortTextNote>[]>(() => ({
-    queryKey: queryKey(),
-    emitter,
-  }));
+    return _eventID
+      ? { kinds: [kinds.ShortTextNote], tags: { e: [_eventID] } }
+      : undefined;
+  });
 };
 
 export const useEmojis = (pubkey: () => string | undefined) => {


### PR DESCRIPTION
## Summary
- Adds `useCoreEventRelations` for v1 core-backed relation reads using repository/query-client plus the events collection.
- Routes `useReactionsOfEvent`, `useRepostsOfEvent`, `useQuotesOfEvent`, and `useRepliesOfEvent` through the new v1 core compatibility wrapper while keeping existing import paths stable.
- Extends the query client with `ensureEventRelations` to emit relation filters through the core transport boundary.

## Test Plan
- [x] `pnpm exec biome check --write src/core/query/query-client.ts src/core/solid/use-event-relations.ts src/core/solid/use-event-relations.test.tsx src/shared/libs/query.ts`
- [x] `pnpm test -- --run src/core/solid/use-event-relations.test.tsx src/core/solid/use-event.test.tsx src/core/query/query-client.test.ts`
- [x] `pnpm run build`
- [x] `pnpm test -- --run`
- [x] `pnpm run check`

## Review Focus
- Please check that the relation hook wrappers preserve the legacy `CacheDataBase<ParsedEventPacket<T>[]>` shape and existing import paths.
- Please check that relation filters map correctly to Nostr tag queries: reactions/reposts/replies use `#e`, quotes use `#q`.
- This PR intentionally keeps the compatibility surface in `src/shared/libs/query.ts`; removing the remaining legacy helpers is left to follow-up tasks.

Linear: EYE-105
