### PR TITLE
EYE-114 route legacy publishing through v1 transport

### DIFF
--- a/src/shared/libs/query.ts
+++ b/src/shared/libs/query.ts
@@ -399,7 +399,7 @@ const initialSendState = (): SendingState => ({
 });
 
 const createSender = () => {
-  const { core, rxNostr } = useRxNostr();
+  const { core } = useRxNostr();
   const [sendState, setSendState] = createStore<SendingState>(
     initialSendState(),
   );
@@ -422,7 +422,7 @@ const createSender = () => {
     });
 
     return new Promise<void>((resolve) => {
-      rxNostr.send(event).subscribe({
+      core.transport.publish(event).subscribe({
         next: (e) => {
           if (e.ok && e.done) {
             setSendState("successAny", true);


### PR DESCRIPTION
## Summary
- Routes the legacy shared publish sender through `core.transport.publish(event)` instead of calling `rxNostr.send(event)` directly.
- Keeps the existing send hook APIs and `SendingState` handling unchanged.
- Leaves optimistic TanStack DB publish mutations for a later v1 step.

## Test Plan
- [x] `pnpm vitest run src/core/transport/rx-nostr-transport.test.ts`
- [x] `pnpm typecheck`

## Review Focus
- Please check that this is intentionally only a boundary move: publish still uses existing hook APIs and state handling, but the direct rx-nostr send call is now isolated behind the v1 transport.
- Please check whether any publish relay option behavior should be added now; this PR preserves the previous default-relay behavior by not passing options.

Linear: EYE-114
