### PR TITLE
EYE-115 remove follower counter cache invalidation

### DIFF
--- a/src/features/User/components/FollowerCounter.tsx
+++ b/src/features/User/components/FollowerCounter.tsx
@@ -1,5 +1,4 @@
 import { type Component, Show, createSignal } from "solid-js";
-import { useInvalidateEventCache } from "../../../context/eventCache";
 import { useI18n } from "../../../i18n";
 import { useFollowers } from "../../../shared/libs/query";
 import { useOpenFollowersColumn } from "../../Column/libs/useOpenColumn";
@@ -12,11 +11,9 @@ const FollowerCounter: Component<{ pubkey?: string }> = (props) => {
     showFollowerCount() ? props.pubkey : undefined,
   );
   const openFollowers = useOpenFollowersColumn();
-  const invalidate = useInvalidateEventCache();
 
   const handleFollowerCountClick = () => {
     if (!showFollowerCount()) {
-      invalidate(["followers", props.pubkey]);
       setShowFollowerCount(true);
       return;
     }


### PR DESCRIPTION
## Summary
- Removes the legacy `EventCacheProvider` invalidation call from `FollowerCounter`.
- Leaves follower count visibility and followers-column opening behavior unchanged.
- Relies on the v1-backed `useFollowers()` compatibility wrapper to fetch when the count becomes visible.

## Test Plan
- [x] `pnpm typecheck`
- [x] `pnpm run check`
- [x] `git diff --check`

## Review Focus
- Please check that removing the manual `["followers", pubkey]` invalidation is safe now that `useFollowers()` delegates to the v1 core social-read hook.
- This PR intentionally does not remove `EventCacheProvider` itself or migrate `InfiniteEvents`.

Linear: EYE-115
