### PR TITLE
EYE-116 remove publish cache invalidations

### DIFF
--- a/src/shared/libs/query.ts
+++ b/src/shared/libs/query.ts
@@ -21,7 +21,6 @@ import {
   type CacheDataBase,
   type CacheKey,
   eventCacheSetter,
-  useInvalidateEventCache,
 } from "../../context/eventCache";
 import { type SendingState, useLoading } from "../../context/loading";
 import { useRxNostr } from "../../context/rxNostr";
@@ -478,8 +477,7 @@ export const useSendShortText = () => {
 };
 
 export const useSendReaction = () => {
-  const { sender, sendState } = createSender();
-  const invalidate = useInvalidateEventCache();
+  const { core, sender, sendState } = createSender();
 
   const sendReaction = (props: {
     content: Reaction["content"];
@@ -509,7 +507,12 @@ export const useSendReaction = () => {
         tags,
       },
       () => {
-        invalidate(["reactionsOf", props.targetEventId]);
+        void core.queryClient.ensureEventRelations({
+          query: {
+            kinds: [kinds.Reaction],
+            tags: { e: [props.targetEventId] },
+          },
+        });
       },
     );
   };
@@ -521,8 +524,7 @@ export const useSendReaction = () => {
 };
 
 export const useSendRepost = () => {
-  const { sender, sendState } = createSender();
-  const invalidate = useInvalidateEventCache();
+  const { core, sender, sendState } = createSender();
 
   const sendRepost = (props: { targetEvent: Event; relay: string }) => {
     const tags = [
@@ -546,7 +548,12 @@ export const useSendRepost = () => {
         content: JSON.stringify(props.targetEvent),
       },
       () => {
-        invalidate(["repostsOf", props.targetEvent.id]);
+        void core.queryClient.ensureEventRelations({
+          query: {
+            kinds: [kinds.Repost, kinds.GenericRepost],
+            tags: { e: [props.targetEvent.id] },
+          },
+        });
       },
     );
   };
@@ -559,7 +566,6 @@ export const useSendRepost = () => {
 
 export const useSendContacts = () => {
   const { core, sender, sendState } = createSender();
-  const invalidate = useInvalidateEventCache();
 
   const sendContacts = (props: {
     pubkey: string;
@@ -575,7 +581,6 @@ export const useSendContacts = () => {
         content: props.content,
       },
       () => {
-        invalidate([kinds.Contacts, props.pubkey]);
         void core.queryClient.ensureEventRelations({
           query: { kinds: [kinds.Contacts], authors: [props.pubkey], limit: 1 },
         });
@@ -591,7 +596,6 @@ export const useSendContacts = () => {
 
 export const useSendProfile = () => {
   const { core, sender, sendState } = createSender();
-  const invalidate = useInvalidateEventCache();
 
   const sendProfile = (props: {
     pubkey: string;
@@ -603,7 +607,6 @@ export const useSendProfile = () => {
         content: JSON.stringify(props.profile),
       },
       () => {
-        invalidate([kinds.Metadata, props.pubkey]);
         void core.queryClient.ensureProfile({ pubkey: props.pubkey });
       },
     );
@@ -617,7 +620,6 @@ export const useSendProfile = () => {
 
 export const useSendMuteList = () => {
   const { core, sender, sendState } = createSender();
-  const invalidate = useInvalidateEventCache();
 
   const sendMuteList = async (props: {
     pubkey: string;
@@ -635,7 +637,6 @@ export const useSendMuteList = () => {
         tags: muteItemsToTags(props.publicItems),
       },
       () => {
-        invalidate([kinds.Mutelist, props.pubkey]);
         void core.queryClient.ensureEventRelations({
           query: { kinds: [kinds.Mutelist], authors: [props.pubkey], limit: 1 },
         });


### PR DESCRIPTION
## Summary
- Removes old `EventCacheProvider` invalidation calls from publish helpers.
- Keeps existing send hook APIs and `SendingState` behavior unchanged.
- Refreshes reaction/repost/contacts/profile/mute-list reads via the v1 `queryClient.ensure...` paths instead.

## Test Plan
- [x] `git diff --check`
- [x] `pnpm vitest run src/core/solid/use-event-relations.test.tsx src/core/solid/use-social-read.test.tsx src/core/solid/use-profile.test.tsx`
- [x] `pnpm typecheck`
- [x] `pnpm run check`

## Review Focus
- Please check that each removed EventCache invalidation has an equivalent or better v1 query-client refresh path.
- This PR intentionally does not migrate `InfiniteEvents`, `createInfiniteRxQuery`, or remove `EventCacheProvider` itself.

Linear: EYE-116
