### PR TITLE
Remove global EventCache writes from RxNostrProvider

### DIFF
--- a/src/context/rxNostr.tsx
+++ b/src/context/rxNostr.tsx
@@ -27,9 +27,7 @@ import { projectRepositoryEvent } from "../core/db/projectors/project-event";
 import { type NostrCore, createNostrCore } from "../core/solid/provider";
 import type RxNostrDevtoolsComp from "../shared/components/devtools/RxNostrDevtools";
 import { mergeSimilarAndRemoveEmptyFilters } from "../shared/libs/mergeFilters";
-import { cacheAndEmitRelatedEvent } from "../shared/libs/query";
 import workerUrl from "../shared/libs/verifierWorker?worker&url";
-import { eventCacheSetter } from "./eventCache";
 import { useRelays } from "./relays";
 
 type Emitter = RxReqEmittable<{ relays: string[] }>["emit"];
@@ -110,11 +108,9 @@ export const RxNostrProvider: ParentComponent = (props) => {
 
   const rxBackwardReq = createRxBackwardReq();
   const emit = rxBackwardReq.emit;
-  const setter = eventCacheSetter();
 
   allMessage$.pipe(filterByType("EVENT"), uniq()).subscribe({
     next: (e) => {
-      cacheAndEmitRelatedEvent(e, emit, setter);
       void ingestNostrCoreEvent(core(), e.event, e.from).catch(() => {
         // Keep the legacy rx-nostr stream alive even if v1 projection rejects.
       });


### PR DESCRIPTION
## Summary
- Removes the global old `EventCacheProvider` write from `RxNostrProvider`'s EVENT stream.
- Keeps the v1 `ingestNostrCoreEvent(...)` repository/projection path intact.
- Keeps legacy `actions.emit` / `emitWithEOSE` compatibility available for still-legacy call sites.

## Test Plan
- [x] `git diff --check`
- [x] `pnpm vitest run src/core/solid/use-event-relations.test.tsx src/core/solid/use-social-read.test.tsx src/core/solid/use-profile.test.tsx`
- [x] `pnpm typecheck`
- [x] `pnpm run check`

## Review Focus
- Please check that global received events still flow into v1 repository/projection via `ingestNostrCoreEvent(...)`.
- Please check that no still-legacy call site loses `actions.emit` / `emitWithEOSE` compatibility.
- This PR intentionally does not migrate `InfiniteEvents`, `createInfiniteRxQuery`, or remove `EventCacheProvider` itself.

Note: Linear MCP was disconnected while creating this PR, so I could not create/link the Linear issue yet.
