### PR TITLE
refactor(core): route infinite events page fetch through v1 core

### DIFF
--- a/src/core/query/query-client.test.ts
+++ b/src/core/query/query-client.test.ts
@@ -14,10 +14,12 @@ import { createNostrCoreQueryClient } from "./query-client";
 const createFakeTransport = () => {
   const events$ = new Subject<NostrTransportEventPacket>();
   const close = vi.fn(() => events$.complete());
+  const complete = vi.fn();
   const emit = vi.fn();
   const subscribe = vi.fn((_options: NostrTransportSubscribeOptions) => ({
     events$: events$.asObservable(),
     emit,
+    complete,
     close,
   }));
   const transport = {
@@ -29,7 +31,7 @@ const createFakeTransport = () => {
     dispose: vi.fn(),
   } as unknown as NostrTransport;
 
-  return { transport, events$, emit, close, subscribe };
+  return { transport, events$, emit, complete, close, subscribe };
 };
 
 const createEvent = (overrides: Partial<NostrEvent> = {}): NostrEvent => ({
@@ -148,6 +150,103 @@ describe("createNostrCoreQueryClient", () => {
     expect(close).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(25);
+    expect(close).toHaveBeenCalledOnce();
+    vi.useRealTimers();
+  });
+
+  test("fetches a backward event page through transport and projects received events", async () => {
+    const { transport, events$, emit, complete, close, subscribe } =
+      createFakeTransport();
+    const repository = new MemoryNostrRepository();
+    const collections = createNostrCollections();
+    const queryClient = createNostrCoreQueryClient({
+      transport,
+      repository,
+      collections,
+      now: () => 456,
+    });
+    const event = createEvent({ id: "page-event" });
+    const packet = {
+      type: "EVENT",
+      from: "wss://relay.example",
+      subId: "sub-1",
+      event,
+    } as const;
+    const resultPromise = queryClient.fetchEventPage({
+      filter: { kinds: [1], limit: 20, until: 100 },
+      relays: ["wss://relay.example"],
+    });
+
+    events$.next(packet);
+    events$.complete();
+
+    await expect(resultPromise).resolves.toEqual([packet]);
+    expect(subscribe).toHaveBeenCalledWith({
+      filters: { kinds: [1], limit: 20, until: 100 },
+      relays: ["wss://relay.example"],
+      mode: "backward",
+    });
+    expect(emit).toHaveBeenCalledWith({ kinds: [1], limit: 20, until: 100 });
+    expect(complete).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+    await expect(repository.getEvent(event.id)).resolves.toBe(event);
+    expect(await collections.events.get(event.id)).toMatchObject({
+      id: event.id,
+      receivedAt: 456,
+      seenRelays: ["wss://relay.example"],
+    });
+  });
+
+  test("deduplicates event page packets by event id while preserving the first relay source", async () => {
+    const { transport, events$ } = createFakeTransport();
+    const queryClient = createNostrCoreQueryClient({
+      transport,
+      repository: new MemoryNostrRepository(),
+      collections: createNostrCollections(),
+    });
+    const event = createEvent({ id: "duplicated-page-event" });
+    const firstPacket = {
+      type: "EVENT",
+      from: "wss://first-relay.example",
+      subId: "sub-1",
+      event,
+    } as const;
+    const secondPacket = {
+      type: "EVENT",
+      from: "wss://second-relay.example",
+      subId: "sub-1",
+      event,
+    } as const;
+    const resultPromise = queryClient.fetchEventPage({
+      filter: { kinds: [1], limit: 20 },
+    });
+
+    events$.next(firstPacket);
+    events$.next(secondPacket);
+    events$.complete();
+
+    await expect(resultPromise).resolves.toEqual([firstPacket]);
+  });
+
+  test("resolves an empty event page after the request timeout", async () => {
+    vi.useFakeTimers();
+    const { transport, close } = createFakeTransport();
+    const queryClient = createNostrCoreQueryClient({
+      transport,
+      repository: new MemoryNostrRepository(),
+      collections: createNostrCollections(),
+      requestTimeoutMs: 25,
+    });
+
+    const resultPromise = queryClient.fetchEventPage({
+      filter: { kinds: [1], limit: 20 },
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(resultPromise).resolves.toEqual([]);
+    expect(close).toHaveBeenCalledOnce();
+    queryClient.dispose();
     expect(close).toHaveBeenCalledOnce();
     vi.useRealTimers();
   });

--- a/src/core/query/query-client.ts
+++ b/src/core/query/query-client.ts
@@ -7,7 +7,12 @@ import type {
   RelayUrl,
 } from "../repository/nostr-repository";
 import { subscribeToTransportEvents } from "../transport/rx-nostr-transport";
-import type { NostrSubscription, NostrTransport } from "../transport/transport";
+import type {
+  NostrSubscription,
+  NostrTransport,
+  NostrTransportEventPacket,
+  NostrTransportFilter,
+} from "../transport/transport";
 
 export type EnsureEventOptions = {
   id: string;
@@ -24,12 +29,20 @@ export type EnsureEventRelationsOptions = {
   relays?: readonly RelayUrl[];
 };
 
+export type FetchEventPageOptions = {
+  filter: NostrTransportFilter;
+  relays?: readonly RelayUrl[];
+};
+
 export type NostrCoreQueryClient = {
   ensureEvent(options: EnsureEventOptions): Promise<NostrEvent | undefined>;
   ensureProfile(options: EnsureProfileOptions): Promise<NostrEvent | undefined>;
   ensureEventRelations(
     options: EnsureEventRelationsOptions,
   ): Promise<NostrEvent[]>;
+  fetchEventPage(
+    options: FetchEventPageOptions,
+  ): Promise<NostrTransportEventPacket[]>;
   dispose(): void;
 };
 
@@ -146,24 +159,54 @@ export const createNostrCoreQueryClient = ({
       const cached = await repository.queryEvents(query);
       subscribeAndEmit(
         {
-          filters: {
-            ids: query.ids ? [...query.ids] : undefined,
-            authors: query.authors ? [...query.authors] : undefined,
-            kinds: query.kinds ? [...query.kinds] : undefined,
-            limit: query.limit,
-            ...Object.fromEntries(
-              Object.entries(query.tags ?? {}).map(([name, values]) => [
-                `#${name}`,
-                [...values],
-              ]),
-            ),
-          },
+          filters: toTransportFilter(query),
           relays,
           mode: "backward",
         },
         { closeOnFirstEvent: false },
       );
       return cached;
+    },
+
+    async fetchEventPage({ filter, relays }) {
+      return new Promise((resolve) => {
+        const packetsByEventId = new Map<string, NostrTransportEventPacket>();
+        let done = false;
+        let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+        const subscription = subscribeToTransportEvents(
+          transport,
+          {
+            filters: filter,
+            relays,
+            mode: "backward",
+          },
+          (packet) => {
+            if (!packetsByEventId.has(packet.event.id)) {
+              packetsByEventId.set(packet.event.id, packet);
+            }
+            void projectTransportEvent(packet.event, packet.from).catch(() => {
+              // Keep page collection resilient if one projection rejects.
+            });
+          },
+        );
+        const close = trackSubscription(subscription);
+        const finish = () => {
+          if (done) {
+            return;
+          }
+          done = true;
+          if (timeoutHandle !== undefined) {
+            clearTimeout(timeoutHandle);
+            timeoutHandle = undefined;
+          }
+          close();
+          resolve([...packetsByEventId.values()]);
+        };
+        timeoutHandle = setTimeout(finish, requestTimeoutMs);
+        subscription.events$.subscribe({ complete: finish });
+        subscription.emit(filter);
+        subscription.complete();
+      });
     },
 
     dispose() {
@@ -174,3 +217,16 @@ export const createNostrCoreQueryClient = ({
     },
   };
 };
+
+const toTransportFilter = (query: NostrEventQuery): NostrTransportFilter => ({
+  ids: query.ids ? [...query.ids] : undefined,
+  authors: query.authors ? [...query.authors] : undefined,
+  kinds: query.kinds ? [...query.kinds] : undefined,
+  limit: query.limit,
+  ...Object.fromEntries(
+    Object.entries(query.tags ?? {}).map(([name, values]) => [
+      `#${name}`,
+      [...values],
+    ]),
+  ),
+});

--- a/src/core/transport/rx-nostr-transport.ts
+++ b/src/core/transport/rx-nostr-transport.ts
@@ -49,6 +49,11 @@ export class RxNostrTransport implements NostrTransport {
       emit(filters) {
         rxReq.emit(toLazyFilters(filters));
       },
+      complete() {
+        if ("over" in rxReq) {
+          rxReq.over();
+        }
+      },
       close() {
         subscriptions.unsubscribe();
         if ("over" in rxReq) {
@@ -101,6 +106,7 @@ export const subscribeToTransportEvents = (
   return {
     events$: subscription.events$,
     emit: subscription.emit,
+    complete: subscription.complete,
     close() {
       observableSubscription.unsubscribe();
       originalClose();

--- a/src/core/transport/transport.ts
+++ b/src/core/transport/transport.ts
@@ -72,6 +72,7 @@ export type NostrTransportPublishPacket = {
 export interface NostrSubscription {
   readonly events$: Observable<NostrTransportEventPacket>;
   emit(filters: NostrTransportFilter | readonly NostrTransportFilter[]): void;
+  complete(): void;
   close(): void;
 }
 

--- a/src/shared/components/InfiniteEvents.tsx
+++ b/src/shared/components/InfiniteEvents.tsx
@@ -1,14 +1,20 @@
 import { createViewportObserver } from "@solid-primitives/intersection-observer";
 import type { Filter } from "nostr-tools";
-import { createRxForwardReq, now, uniq } from "rx-nostr";
-import { map, tap } from "rxjs";
-import { type Component, For, Match, Switch, from, onMount } from "solid-js";
-import { eventCacheSetter } from "../../context/eventCache";
-import { useRxNostr } from "../../context/rxNostr";
+import { compareEvents } from "rx-nostr";
+import {
+  type Component,
+  For,
+  Match,
+  Switch,
+  onCleanup,
+  onMount,
+} from "solid-js";
+import { createStore } from "solid-js/store";
+import { ingestNostrCoreEvent, useRxNostr } from "../../context/rxNostr";
+import type { NostrTransportFilter } from "../../core/transport/transport";
 import { useI18n } from "../../i18n";
 import { parseEventPacket } from "../libs/parser";
-import { cacheAndEmitRelatedEvent, createInfiniteRxQuery } from "../libs/query";
-import { toArrayScan } from "../libs/rxjs";
+import { createInfiniteRxQuery } from "../libs/query";
 import Event from "./Event";
 
 const InfiniteEvents: Component<{
@@ -16,39 +22,43 @@ const InfiniteEvents: Component<{
   relays?: string[];
 }> = (props) => {
   const t = useI18n();
-
-  const latestRxReq = createRxForwardReq();
-  const setter = eventCacheSetter();
-
-  const {
-    rxNostr,
-    actions: { emit },
-  } = useRxNostr();
-
-  const latestEvents = from(
-    rxNostr
-      .use(latestRxReq, {
-        on: {
-          relays: props.relays,
-          defaultReadRelays: !props.relays,
-        },
-      })
-      .pipe(
-        uniq(),
-        tap({
-          next: (e) => {
-            cacheAndEmitRelatedEvent(e, emit, setter);
-          },
-        }),
-        map((e) => parseEventPacket(e)),
-        toArrayScan(true),
-      ),
-  );
+  const { core } = useRxNostr();
+  const [latestEvents, setLatestEvents] = createStore<
+    ReturnType<typeof parseEventPacket>[]
+  >([]);
 
   onMount(() => {
-    latestRxReq.emit({
-      ...props.filter,
-      since: now,
+    const subscription = core.transport.subscribe({
+      filters: {
+        ...(props.filter as NostrTransportFilter),
+        since: Math.floor(Date.now() / 1000),
+      },
+      relays: props.relays,
+      defaultReadRelays: !props.relays,
+      mode: "forward",
+    });
+    const observableSubscription = subscription.events$.subscribe({
+      next: (packet) => {
+        void ingestNostrCoreEvent(core, packet.event, packet.from).catch(() => {
+          // Keep the live feed stream alive if projection rejects.
+        });
+        const parsed = parseEventPacket(packet);
+        setLatestEvents((prev) => {
+          if (prev.some((event) => event.raw.id === parsed.raw.id)) {
+            return prev;
+          }
+          return [parsed, ...prev].sort((a, b) => -compareEvents(a.raw, b.raw));
+        });
+      },
+    });
+    subscription.emit({
+      ...(props.filter as NostrTransportFilter),
+      since: Math.floor(Date.now() / 1000),
+    });
+
+    onCleanup(() => {
+      observableSubscription.unsubscribe();
+      subscription.close();
     });
   });
 
@@ -68,7 +78,7 @@ const InfiniteEvents: Component<{
 
   return (
     <div class="h-full divide-y">
-      <For each={latestEvents()}>
+      <For each={latestEvents}>
         {(event) => (
           <Event
             event={event}

--- a/src/shared/libs/parser/index.ts
+++ b/src/shared/libs/parser/index.ts
@@ -1,5 +1,4 @@
 import { type NostrEvent, kinds } from "nostr-tools";
-import type { EventPacket } from "rx-nostr";
 import { parseMetadata } from "./0_metadata";
 import { parseShortTextNote } from "./1_shortTextNote";
 import { parseContacts } from "./3_contacts";
@@ -32,7 +31,12 @@ export const parseNostrEvent = (input: NostrEvent) => {
   }
 };
 
-export const parseEventPacket = (input: EventPacket) => {
+export type EventPacketLike = {
+  from: string;
+  event: NostrEvent;
+};
+
+export const parseEventPacket = (input: EventPacketLike) => {
   return {
     from: input.from,
     raw: input.event,

--- a/src/shared/libs/query.ts
+++ b/src/shared/libs/query.ts
@@ -1,27 +1,16 @@
 import { type Filter, kinds } from "nostr-tools";
 import { normalizeURL } from "nostr-tools/utils";
 import type { Event, EventParameters } from "nostr-typedef";
-import {
-  type EventPacket,
-  type LazyFilter,
-  type RxReqEmittable,
-  compareEvents,
-  createRxBackwardReq,
-  uniq,
-} from "rx-nostr";
-import { map, tap } from "rxjs";
+import { compareEvents } from "rx-nostr";
 import {
   type Accessor,
   createEffect,
   createMemo,
   createSignal,
+  onCleanup,
 } from "solid-js";
 import { createStore, reconcile } from "solid-js/store";
-import {
-  type CacheDataBase,
-  type CacheKey,
-  eventCacheSetter,
-} from "../../context/eventCache";
+import type { CacheDataBase } from "../../context/eventCache";
 import { type SendingState, useLoading } from "../../context/loading";
 import { useRxNostr } from "../../context/rxNostr";
 import { useCoreEventByID } from "../../core/solid/use-event";
@@ -35,6 +24,7 @@ import {
   useCoreFollowers,
   useCoreUserList,
 } from "../../core/solid/use-social-read";
+import type { NostrTransportFilter } from "../../core/transport/transport";
 import { genID } from "./id";
 import {
   type ParsedEventPacket,
@@ -63,11 +53,7 @@ export const createInfiniteRxQuery = (
   // TODO: propsが変化したら再取得する
   // TODO: abort controller
 
-  const {
-    rxNostr,
-    actions: { emit },
-  } = useRxNostr();
-  const setter = eventCacheSetter();
+  const { core } = useRxNostr();
 
   const [data, setData] = createStore<{
     pages: ParsedEventPacket[][];
@@ -76,6 +62,7 @@ export const createInfiniteRxQuery = (
   });
   const [isFetching, setIsFetching] = createSignal(false);
   const [hasNextPage, setHasNextPage] = createSignal(false);
+  let disposed = false;
 
   /** 取得済みイベントの中で最も古いイベントのcreated_at */
   let oldestCreatedAt: number | undefined = Math.min(
@@ -85,60 +72,44 @@ export const createInfiniteRxQuery = (
   );
 
   const fetchNextPage = async () => {
-    const rxReq = createRxBackwardReq();
+    if (isFetching()) {
+      return;
+    }
     setIsFetching(true);
 
-    const page = await new Promise<ParsedEventPacket[]>((resolve) => {
-      const events: ParsedEventPacket[] = [];
-      rxNostr
-        .use(rxReq, {
-          on: {
-            relays: props().relays,
-            defaultReadRelays: !props().relays,
+    const currentProps = props();
+    const packets = oldestCreatedAt
+      ? await core.queryClient.fetchEventPage({
+          filter: {
+            ...(currentProps.filter as NostrTransportFilter),
+            limit: currentProps.limit,
+            until: oldestCreatedAt - 1,
           },
+          relays: currentProps.relays,
         })
-        .pipe(
-          uniq(),
-          tap((e) => cacheAndEmitRelatedEvent(e, emit, setter)),
-          map((e) => parseEventPacket(e)),
-        )
-        .subscribe({
-          next: (e) => {
-            events.push(e);
-          },
-          complete: () => {
-            const sliced = events
-              .sort((a, b) => -compareEvents(a.raw, b.raw))
-              .slice(0, props().limit);
+      : [];
 
-            oldestCreatedAt = sliced.at(-1)?.raw.created_at;
+    const page = packets
+      .map((packet) => parseEventPacket(packet))
+      .sort((a, b) => -compareEvents(a.raw, b.raw))
+      .slice(0, currentProps.limit);
 
-            resolve(sliced);
-          },
-        });
+    oldestCreatedAt = page.at(-1)?.raw.created_at;
 
-      if (oldestCreatedAt) {
-        rxReq.emit({
-          ...props().filter,
-          limit: props().limit,
-          until: oldestCreatedAt - 1,
-        });
-      }
-      rxReq.over();
-    });
-    if (page.length > 0) {
+    if (!disposed && page.length > 0) {
       setData("pages", data.pages.length, page);
     }
-    setIsFetching(false);
-
-    if (page.length < props().limit) {
-      setHasNextPage(false);
-    } else {
-      setHasNextPage(true);
+    if (!disposed) {
+      setIsFetching(false);
+      setHasNextPage(page.length >= currentProps.limit);
     }
   };
 
-  fetchNextPage();
+  void fetchNextPage();
+
+  onCleanup(() => {
+    disposed = true;
+  });
 
   return {
     data,
@@ -146,169 +117,6 @@ export const createInfiniteRxQuery = (
     hasNextPage,
     fetchNextPage,
   };
-};
-
-// TODO: ここで各kindのstaleTimeも設定する
-const getCacheKey = (
-  parsed: ParsedEventPacket,
-): {
-  single?: CacheKey[];
-  multiple?: CacheKey[];
-} => {
-  switch (parsed.parsed.kind) {
-    case kinds.ShortTextNote: {
-      const replyTarget = parsed.parsed.replyOrRoot
-        ? ["repliesOf", parsed.parsed.replyOrRoot.id]
-        : [];
-
-      const quotes = parsed.parsed.tags
-        .filter((tag) => tag.kind === "q")
-        .map((tag) => ["quotesOf", tag.id]);
-
-      return {
-        single: [["event", parsed.parsed.id]],
-        multiple: [replyTarget, ...quotes],
-      };
-    }
-    case kinds.Metadata:
-    case kinds.Contacts:
-    case kinds.Mutelist:
-    case kinds.UserEmojiList:
-      // 特定ユーザーについて最新1件を取得できれば良いもの
-      return { single: [[parsed.raw.kind, parsed.parsed.pubkey]] };
-    case kinds.Emojisets:
-      return {
-        single: [
-          [kinds.Emojisets, parsed.parsed.pubkey, parsed.parsed.identifier],
-        ],
-      };
-    case kinds.Repost: {
-      // そのidのShortTextNoteのリポスト一覧
-      const repostsOf = parsed.parsed.tags
-        .filter((tag) => tag.kind === "e")
-        .map((tag) => ["repostsOf", tag.id]);
-      return { multiple: repostsOf };
-    }
-    case kinds.Reaction: {
-      // そのidのShortTextNoteのリアクション一覧
-      return {
-        multiple: [["reactionsOf", parsed.parsed.targetEvent.id]],
-      };
-    }
-    default:
-      console.warn(`[getQueryKey] unknown kind: ${parsed.raw.kind}`);
-      return {
-        multiple: [["event", parsed.raw.id]],
-      };
-  }
-};
-
-const getRelatedEventFilters = (parsed: ParsedEventPacket): LazyFilter[] => {
-  switch (parsed.parsed.kind) {
-    // 何もemitしないkind
-    case kinds.Contacts:
-    case kinds.Mutelist:
-    case kinds.Emojisets:
-      return [];
-    case kinds.Metadata:
-      return [
-        // {
-        //   kinds: [kinds.Contacts],
-        //   authors: [parsed.parsed.pubkey],
-        // },
-      ];
-    case kinds.ShortTextNote: {
-      const authors = parsed.parsed.tags
-        .filter((tag) => tag.kind === "p")
-        .map((tag) => tag.pubkey);
-      authors.push(parsed.parsed.pubkey);
-
-      // const relatedEvents = parsed.parsed.tags
-      //   .filter((tag) => tag.kind === "e" || tag.kind === "q")
-      //   .map((tag) => tag.id);
-
-      return [
-        {
-          kinds: [kinds.Metadata],
-          authors: authors,
-        },
-        // TODO: これを入れると無限ループする?
-        // {
-        //   kinds: [kinds.ShortTextNote],
-        //   ids: relatedEvents,
-        // },
-        {
-          kinds: [kinds.Reaction, kinds.Repost],
-          "#e": [parsed.parsed.id],
-        },
-      ];
-    }
-    case kinds.Repost: {
-      return [
-        {
-          kinds: [kinds.ShortTextNote],
-          ids: [parsed.parsed.targetEventID],
-          // limit: 1,
-        },
-      ];
-    }
-    case kinds.Reaction:
-      return [
-        {
-          kinds: [kinds.Metadata],
-          authors: [parsed.parsed.pubkey],
-        },
-      ];
-    case kinds.UserEmojiList: {
-      const referencedSets = parsed.parsed.emojiSets;
-      return referencedSets.map((set) => ({
-        kinds: [kinds.Emojisets],
-        authors: [set.pubkey],
-        "#d": [set.tag],
-      }));
-    }
-    default:
-      console.warn(`[relatedEventFilters] unknown kind: ${parsed.raw.kind}`);
-      return [];
-  }
-};
-
-export const cacheAndEmitRelatedEvent = (
-  e: EventPacket,
-  emit: RxReqEmittable<{ relays: string[] }>["emit"],
-  cacheSetter: ReturnType<typeof eventCacheSetter>,
-) => {
-  const parsed = parseEventPacket(e);
-  const queryKeys = getCacheKey(parsed);
-
-  // 最新1件のみをcacheに保存する
-  for (const queryKey of queryKeys.single ?? []) {
-    cacheSetter<ParsedEventPacket>(queryKey, (prev) => {
-      if (prev && prev.raw.created_at > parsed.raw.created_at) {
-        return prev;
-      }
-      return parsed;
-    });
-  }
-
-  // すべてのイベントをcacheに保存する
-  for (const queryKey of queryKeys.multiple ?? []) {
-    cacheSetter<ParsedEventPacket[]>(queryKey, (prev) => {
-      if (prev) {
-        // 既に同じイベントがあれば追加しない
-        if (prev.some((p) => p.raw.id === parsed.raw.id)) {
-          return prev;
-        }
-
-        // TODO: sort
-        return [parsed, ...prev];
-      }
-      return [parsed];
-    });
-  }
-
-  const relatedEventFilters = getRelatedEventFilters(parsed);
-  emit(relatedEventFilters);
 };
 
 export const useEventByID = <T = ReturnType<typeof parseNostrEvent>>(


### PR DESCRIPTION
## Summary
- InfiniteEvents のページ取得を v1 core queryClient / transport 経由へ移行した。
- 旧 EventCache へのページ書き込みを外し、v1 repository / projection に流すようにした。
- fetchEventPage のテストを追加し、EOSE / timeout / dedup / projection を確認した。

## Test Plan
- [x] `pnpm vitest run src/core/query/query-client.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm run check`
- [x] `pnpm exec tsc -b`

## Review Focus
- `fetchEventPage` が backward ページ取得を v1 transport/queryClient 境界に閉じていて、旧 EventCache へ戻っていないこと。
- ページ取得の完了条件が EOSE / timeout ベースで、forward live subscription と混同していないこと。
- 取得済みページの重複 eventId を先着 relay で保持する挙動が意図どおりであること。

Linear: EYE-118
